### PR TITLE
iwlwifi: gen3 peripheral scratch structure

### DIFF
--- a/userland/capsule_driver_iwlwifi/src/firmware/gen3/dram_map/align.rs
+++ b/userland/capsule_driver_iwlwifi/src/firmware/gen3/dram_map/align.rs
@@ -1,0 +1,21 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Round a byte cursor up to a power-of-two alignment.
+
+pub(super) fn align_up(v: u64, align: u64) -> u64 {
+    (v + align - 1) & !(align - 1)
+}

--- a/userland/capsule_driver_iwlwifi/src/firmware/gen3/dram_map/classify.rs
+++ b/userland/capsule_driver_iwlwifi/src/firmware/gen3/dram_map/classify.rs
@@ -1,0 +1,44 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Partition the runtime sections into LMAC, UMAC and paged images.
+
+use alloc::vec::Vec;
+
+use super::super::image::sections;
+use super::markers::{SEP_CPU1_CPU2, SEP_PAGING};
+use super::types::FwLayout;
+
+/// Walk the runtime sections and split them at the two separators: the run
+/// before the CPU1/CPU2 separator is LMAC, the run before the paging separator
+/// is UMAC, the rest is paged. The separator sections advance the phase and are
+/// dropped; every other section joins the image for the current phase.
+pub fn classify(blob: &[u8]) -> FwLayout<'_> {
+    let mut out = FwLayout { lmac: Vec::new(), umac: Vec::new(), virt: Vec::new() };
+    let mut phase = 0u8;
+    for s in sections(blob) {
+        match s.load_offset {
+            SEP_CPU1_CPU2 if phase == 0 => phase = 1,
+            SEP_PAGING if phase <= 1 => phase = 2,
+            _ => match phase {
+                0 => out.lmac.push(s),
+                1 => out.umac.push(s),
+                _ => out.virt.push(s),
+            },
+        }
+    }
+    out
+}

--- a/userland/capsule_driver_iwlwifi/src/firmware/gen3/dram_map/markers.rs
+++ b/userland/capsule_driver_iwlwifi/src/firmware/gen3/dram_map/markers.rs
@@ -1,0 +1,26 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Section markers and placement granularity for the firmware image.
+
+/// Section load offset marking the LMAC/UMAC boundary (`CPU1_CPU2_SEPARATOR`).
+pub(super) const SEP_CPU1_CPU2: u32 = 0xFFFF_CCCC;
+/// Section load offset marking the boundary before the paged image
+/// (`PAGING_SEPARATOR_SECTION`).
+pub(super) const SEP_PAGING: u32 = 0xAAAA_BBBB;
+/// Each firmware chunk is placed on its own page, as the Linux driver allocates
+/// one coherent block per section.
+pub(super) const CHUNK_ALIGN: u64 = 4096;

--- a/userland/capsule_driver_iwlwifi/src/firmware/gen3/dram_map/mod.rs
+++ b/userland/capsule_driver_iwlwifi/src/firmware/gen3/dram_map/mod.rs
@@ -1,0 +1,33 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Assemble the firmware DRAM image map the gen3 boot ROM reads from peripheral
+//! scratch. The runtime image is a flat section list split by two separators
+//! into LMAC, UMAC and paged images, the way `iwl_pcie_init_fw_sec` does it in
+//! Linux iwlwifi. `classify` is the pure partition; `stage` copies each section
+//! into the DMA region and reports each chunk's page-aligned device address.
+
+mod align;
+mod classify;
+mod markers;
+mod placement;
+mod stage;
+mod types;
+
+pub use classify::classify;
+pub use placement::DramPlacement;
+pub use stage::stage;
+pub use types::FwLayout;

--- a/userland/capsule_driver_iwlwifi/src/firmware/gen3/dram_map/placement.rs
+++ b/userland/capsule_driver_iwlwifi/src/firmware/gen3/dram_map/placement.rs
@@ -1,0 +1,32 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The device-physical address of every firmware chunk after staging.
+
+use alloc::vec::Vec;
+
+/// Each firmware chunk's device address, grouped by image. The addresses go
+/// straight into the `iwl_prph_scratch` DRAM arrays.
+pub struct DramPlacement {
+    /// LMAC chunk device addresses, in load order.
+    pub lmac: Vec<u64>,
+    /// UMAC chunk device addresses, in load order.
+    pub umac: Vec<u64>,
+    /// Paged chunk device addresses, in load order.
+    pub virt: Vec<u64>,
+    /// Total bytes written into the staging region.
+    pub staged_bytes: usize,
+}

--- a/userland/capsule_driver_iwlwifi/src/firmware/gen3/dram_map/stage.rs
+++ b/userland/capsule_driver_iwlwifi/src/firmware/gen3/dram_map/stage.rs
@@ -1,0 +1,67 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Copy every firmware section into the DMA staging region and report each
+//! chunk's page-aligned device address.
+
+use alloc::vec::Vec;
+
+use super::super::image::Section;
+use super::super::prph_scratch::MAX_DRAM_ENTRY;
+use super::align::align_up;
+use super::classify::classify;
+use super::markers::CHUNK_ALIGN;
+use super::placement::DramPlacement;
+
+/// Stage the firmware images into `user_va` (the same buffer the device sees at
+/// `device_addr`) and return each chunk's device address. Fails if an image has
+/// more than [`MAX_DRAM_ENTRY`] chunks or the region cannot hold the images.
+///
+/// # Safety
+/// `user_va` must point to at least `capacity` writable bytes and `device_addr`
+/// must be the physical address the device sees for that same region.
+pub unsafe fn stage(
+    blob: &[u8],
+    user_va: u64,
+    device_addr: u64,
+    capacity: usize,
+) -> Result<DramPlacement, &'static str> {
+    let l = classify(blob);
+    if l.lmac.len() > MAX_DRAM_ENTRY
+        || l.umac.len() > MAX_DRAM_ENTRY
+        || l.virt.len() > MAX_DRAM_ENTRY
+    {
+        return Err("iwlwifi: firmware image has more chunks than the DRAM map holds");
+    }
+    let mut cursor = 0u64;
+    let mut place = |secs: &[Section]| -> Result<Vec<u64>, &'static str> {
+        let mut addrs = Vec::with_capacity(secs.len());
+        for s in secs {
+            cursor = align_up(cursor, CHUNK_ALIGN);
+            if cursor as usize + s.data.len() > capacity {
+                return Err("iwlwifi: firmware images overrun the staging region");
+            }
+            core::ptr::copy_nonoverlapping(s.data.as_ptr(), (user_va + cursor) as *mut u8, s.data.len());
+            addrs.push(device_addr + cursor);
+            cursor += s.data.len() as u64;
+        }
+        Ok(addrs)
+    };
+    let lmac = place(&l.lmac)?;
+    let umac = place(&l.umac)?;
+    let virt = place(&l.virt)?;
+    Ok(DramPlacement { lmac, umac, virt, staged_bytes: cursor as usize })
+}

--- a/userland/capsule_driver_iwlwifi/src/firmware/gen3/dram_map/types.rs
+++ b/userland/capsule_driver_iwlwifi/src/firmware/gen3/dram_map/types.rs
@@ -1,0 +1,31 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The runtime image partitioned into its three sub-images, in load order.
+
+use alloc::vec::Vec;
+
+use super::super::image::Section;
+
+/// The runtime sections grouped by which image they belong to.
+pub struct FwLayout<'a> {
+    /// LMAC sections: the run before the CPU1/CPU2 separator.
+    pub lmac: Vec<Section<'a>>,
+    /// UMAC sections: the run between the two separators.
+    pub umac: Vec<Section<'a>>,
+    /// Paged ("virtual") sections: the run after the paging separator.
+    pub virt: Vec<Section<'a>>,
+}

--- a/userland/capsule_driver_iwlwifi/src/firmware/gen3/mod.rs
+++ b/userland/capsule_driver_iwlwifi/src/firmware/gen3/mod.rs
@@ -29,12 +29,16 @@
 pub mod boot;
 pub mod csr;
 pub mod ctxt_info;
+pub mod dram_map;
 pub mod image;
+pub mod prph_scratch;
 pub mod rx_mpdu;
 pub mod tx_cmd;
 
 pub use boot::kick;
 pub use ctxt_info::{CtxtInfoGen3, CTXT_INFO_GEN3_SIZE};
+pub use dram_map::{classify, stage, DramPlacement, FwLayout};
 pub use image::{find_iml, sections, Section};
+pub use prph_scratch::{DramImage, PrphScratch, PRPH_SCRATCH_SIZE};
 pub use rx_mpdu::extract_mpdu;
 pub use tx_cmd::{TX_CMD, TX_CMD_GEN3_HDR};

--- a/userland/capsule_driver_iwlwifi/src/firmware/gen3/prph_scratch/flags.rs
+++ b/userland/capsule_driver_iwlwifi/src/firmware/gen3/prph_scratch/flags.rs
@@ -1,0 +1,34 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Control-flag bits for `iwl_prph_scratch.control`. Values from the Linux
+//! `iwl_prph_scratch_flags` and `iwl_prph_scratch_ext_flags` enums.
+
+pub const CTRL_IMR_DEBUG_EN: u32 = 1 << 1;
+pub const CTRL_EARLY_DEBUG_EN: u32 = 1 << 4;
+pub const CTRL_EDBG_DEST_DRAM: u32 = 1 << 8;
+pub const CTRL_RB_SIZE_4K: u32 = 1 << 16;
+pub const CTRL_MTR_MODE: u32 = 1 << 17;
+pub const CTRL_MTR_FORMAT: u32 = (1 << 18) | (1 << 19);
+pub const CTRL_RB_SIZE_EXT_MASK: u32 = 0xf << 20;
+pub const CTRL_RB_SIZE_EXT_8K: u32 = 8 << 20;
+pub const CTRL_RB_SIZE_EXT_12K: u32 = 9 << 20;
+pub const CTRL_RB_SIZE_EXT_16K: u32 = 10 << 20;
+pub const CTRL_SCU_FORCE_ACTIVE: u32 = 1 << 29;
+
+pub const CTRL_EXT_URM_FW: u32 = 1 << 4;
+pub const CTRL_EXT_URM_PERM: u32 = 1 << 5;
+pub const CTRL_EXT_32KHZ_CLK_VALID: u32 = 1 << 8;

--- a/userland/capsule_driver_iwlwifi/src/firmware/gen3/prph_scratch/layout.rs
+++ b/userland/capsule_driver_iwlwifi/src/firmware/gen3/prph_scratch/layout.rs
@@ -1,0 +1,42 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Packed field offsets and sizes for `iwl_prph_scratch`. ctrl_cfg begins at
+//! zero, so these are also the offsets inside `iwl_prph_scratch_ctrl_cfg`. The
+//! DRAM map holds three image arrays then an fseq array, each `__le64`.
+
+/// Entries per firmware image DRAM array (`IWL_MAX_DRAM_ENTRY`).
+pub const MAX_DRAM_ENTRY: usize = 64;
+/// Entries in the FSEQ image DRAM array (`IWL_NUM_DRAM_FSEQ_ENTRIES`).
+pub const FSEQ_ENTRIES: usize = 8;
+/// Total size of the packed `iwl_prph_scratch` structure, in bytes.
+pub const PRPH_SCRATCH_SIZE: usize = 1724;
+
+pub(super) const OFF_VERSION_MAC_ID: usize = 0;
+pub(super) const OFF_VERSION_VERSION: usize = 2;
+pub(super) const OFF_VERSION_SIZE: usize = 4;
+pub(super) const OFF_CONTROL_FLAGS: usize = 8;
+pub(super) const OFF_CONTROL_FLAGS_EXT: usize = 12;
+pub(super) const OFF_PNVM_BASE: usize = 16;
+pub(super) const OFF_PNVM_SIZE: usize = 24;
+pub(super) const OFF_RBD_FREE: usize = 48;
+pub(super) const OFF_REDUCE_POWER_BASE: usize = 60;
+pub(super) const OFF_REDUCE_POWER_SIZE: usize = 68;
+pub(super) const OFF_UMAC_IMG: usize = 124;
+pub(super) const OFF_LMAC_IMG: usize = OFF_UMAC_IMG + MAX_DRAM_ENTRY * 8;
+pub(super) const OFF_VIRTUAL_IMG: usize = OFF_LMAC_IMG + MAX_DRAM_ENTRY * 8;
+/// ctrl_cfg size in dwords, written into the version.size field.
+pub(super) const CTRL_CFG_DWORDS: u16 = 84 / 4;

--- a/userland/capsule_driver_iwlwifi/src/firmware/gen3/prph_scratch/le.rs
+++ b/userland/capsule_driver_iwlwifi/src/firmware/gen3/prph_scratch/le.rs
@@ -1,0 +1,35 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Little-endian field writers into a packed byte buffer.
+
+pub(super) fn w16(buf: &mut [u8], off: usize, val: u16) {
+    buf[off..off + 2].copy_from_slice(&val.to_le_bytes());
+}
+
+pub(super) fn w32(buf: &mut [u8], off: usize, val: u32) {
+    buf[off..off + 4].copy_from_slice(&val.to_le_bytes());
+}
+
+pub(super) fn w64(buf: &mut [u8], off: usize, val: u64) {
+    buf[off..off + 8].copy_from_slice(&val.to_le_bytes());
+}
+
+pub(super) fn w64_array(buf: &mut [u8], base: usize, addrs: &[u64]) {
+    for (i, &addr) in addrs.iter().enumerate() {
+        w64(buf, base + i * 8, addr);
+    }
+}

--- a/userland/capsule_driver_iwlwifi/src/firmware/gen3/prph_scratch/mod.rs
+++ b/userland/capsule_driver_iwlwifi/src/firmware/gen3/prph_scratch/mod.rs
@@ -1,0 +1,29 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The gen3 peripheral-scratch block the boot ROM reads via context info: the
+//! control flags, the platform-NVM and reduce-power addresses, the receive-
+//! buffer ring, and the firmware DRAM image map. Layout from `iwl_prph_scratch`
+//! (Linux pcie/iwl-context-info-v2.h): a packed, little-endian 1724-byte struct.
+
+pub mod flags;
+mod le;
+pub mod layout;
+mod scratch;
+mod write;
+
+pub use layout::{FSEQ_ENTRIES, MAX_DRAM_ENTRY, PRPH_SCRATCH_SIZE};
+pub use scratch::{DramImage, PrphScratch};

--- a/userland/capsule_driver_iwlwifi/src/firmware/gen3/prph_scratch/scratch.rs
+++ b/userland/capsule_driver_iwlwifi/src/firmware/gen3/prph_scratch/scratch.rs
@@ -1,0 +1,53 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The peripheral-scratch fields the boot ROM reads. All addresses are host-
+//! physical (the value a DMA grant reports as `device_addr`).
+
+/// A firmware DRAM image as its chunk physical addresses, one chunk up to 32 KiB.
+#[derive(Clone, Copy, Default)]
+pub struct DramImage<'a> {
+    /// UMAC image chunk addresses, in load order.
+    pub umac: &'a [u64],
+    /// LMAC image chunk addresses, in load order.
+    pub lmac: &'a [u64],
+    /// Paged ("virtual") image chunk addresses, in load order.
+    pub virt: &'a [u64],
+}
+
+/// The addresses and flags the boot ROM reads from peripheral scratch.
+pub struct PrphScratch<'a> {
+    /// MAC hardware id echoed to firmware (version.mac_id).
+    pub mac_id: u16,
+    /// Context-info/HW version echoed to firmware (version.version).
+    pub version: u16,
+    /// FH configuration flags (see [`super::flags`]).
+    pub control_flags: u32,
+    /// Extended configuration flags (see [`super::flags`]).
+    pub control_flags_ext: u32,
+    /// Platform-NVM table physical address, or zero until PNVM is loaded.
+    pub pnvm_base: u64,
+    /// Platform-NVM table size in bytes.
+    pub pnvm_size: u32,
+    /// Reduce-power table physical address, or zero if none.
+    pub reduce_power_base: u64,
+    /// Reduce-power table size in bytes.
+    pub reduce_power_size: u32,
+    /// Free receive-buffer-descriptor ring physical address.
+    pub free_rbd_addr: u64,
+    /// Firmware image DRAM map.
+    pub dram: DramImage<'a>,
+}

--- a/userland/capsule_driver_iwlwifi/src/firmware/gen3/prph_scratch/write.rs
+++ b/userland/capsule_driver_iwlwifi/src/firmware/gen3/prph_scratch/write.rs
@@ -1,0 +1,52 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Serialize a [`PrphScratch`] into its packed 1724-byte form.
+
+use super::layout::*;
+use super::le::{w16, w32, w64, w64_array};
+use super::scratch::PrphScratch;
+
+impl PrphScratch<'_> {
+    /// Write the structure into the first [`PRPH_SCRATCH_SIZE`] bytes of `buf`,
+    /// zeroing that region first. Returns false if `buf` is too small or a DRAM
+    /// image carries more than [`MAX_DRAM_ENTRY`] chunks, which would silently
+    /// drop firmware rather than fault.
+    pub fn write(&self, buf: &mut [u8]) -> bool {
+        if buf.len() < PRPH_SCRATCH_SIZE
+            || self.dram.umac.len() > MAX_DRAM_ENTRY
+            || self.dram.lmac.len() > MAX_DRAM_ENTRY
+            || self.dram.virt.len() > MAX_DRAM_ENTRY
+        {
+            return false;
+        }
+        buf[..PRPH_SCRATCH_SIZE].fill(0);
+        w16(buf, OFF_VERSION_MAC_ID, self.mac_id);
+        w16(buf, OFF_VERSION_VERSION, self.version);
+        w16(buf, OFF_VERSION_SIZE, CTRL_CFG_DWORDS);
+        w32(buf, OFF_CONTROL_FLAGS, self.control_flags);
+        w32(buf, OFF_CONTROL_FLAGS_EXT, self.control_flags_ext);
+        w64(buf, OFF_PNVM_BASE, self.pnvm_base);
+        w32(buf, OFF_PNVM_SIZE, self.pnvm_size);
+        w64(buf, OFF_RBD_FREE, self.free_rbd_addr);
+        w64(buf, OFF_REDUCE_POWER_BASE, self.reduce_power_base);
+        w32(buf, OFF_REDUCE_POWER_SIZE, self.reduce_power_size);
+        w64_array(buf, OFF_UMAC_IMG, self.dram.umac);
+        w64_array(buf, OFF_LMAC_IMG, self.dram.lmac);
+        w64_array(buf, OFF_VIRTUAL_IMG, self.dram.virt);
+        true
+    }
+}

--- a/userland/iwlwifi_proofs/src/dram_map_tests.rs
+++ b/userland/iwlwifi_proofs/src/dram_map_tests.rs
@@ -1,0 +1,82 @@
+// NONOS Operating System (AGPL-3.0-or-later)
+//! Ground-truth proofs for the gen3 firmware DRAM map against the real AX210
+//! (so-a0-gf-a0) image. The section list splits into three images at the two
+//! separator markers; these pin the split (15 LMAC, 16 UMAC, 24 paged), a few
+//! per-image section sizes and offsets read straight from the image, and the
+//! page-aligned device addresses `stage` reports. A wrong separator magic or a
+//! misplaced boundary moves firmware into the wrong image and fails here.
+
+use crate::gen3::dram_map::{classify, stage};
+
+const AX210: &[u8] =
+    include_bytes!("../../../nonos-bootloader/firmware/intel/iwlwifi-so-a0-gf-a0-86.ucode");
+
+#[test]
+fn the_image_splits_into_15_lmac_16_umac_24_paged() {
+    let l = classify(AX210);
+    assert_eq!(l.lmac.len(), 15, "LMAC sections before the CPU1/CPU2 separator");
+    assert_eq!(l.umac.len(), 16, "UMAC sections between the separators");
+    assert_eq!(l.virt.len(), 24, "paged sections after the paging separator");
+
+    // The separators themselves are dropped, so no chunk carries a magic offset.
+    for s in l.lmac.iter().chain(&l.umac).chain(&l.virt) {
+        assert_ne!(s.load_offset, 0xFFFF_CCCC);
+        assert_ne!(s.load_offset, 0xAAAA_BBBB);
+    }
+}
+
+#[test]
+fn the_image_boundaries_match_the_real_bytes() {
+    let l = classify(AX210);
+    // First LMAC section: the small header block at 0x00440000.
+    assert_eq!(l.lmac[0].load_offset, 0x0044_0000);
+    assert_eq!(l.lmac[0].data.len(), 1_656);
+    // Last LMAC section before the CPU1/CPU2 separator.
+    assert_eq!(l.lmac[14].load_offset, 0x0062_9980);
+    assert_eq!(l.lmac[14].data.len(), 22_720);
+    // First UMAC section (offsets carry the high control bits set in the image).
+    assert_eq!(l.umac[0].load_offset, 0x8044_0000);
+    assert_eq!(l.umac[0].data.len(), 1_656);
+    // First paged section after the paging separator.
+    assert_eq!(l.virt[0].load_offset, 0x0000_0000);
+    assert_eq!(l.virt[0].data.len(), 1_656);
+    assert_eq!(l.virt[23].load_offset, 0x010B_0000);
+}
+
+#[test]
+fn stage_places_each_chunk_on_its_own_page_and_copies_it() {
+    // A staging region large enough for the whole runtime image.
+    let mut region = vec![0u8; 2 * 1024 * 1024];
+    let user_va = region.as_mut_ptr() as u64;
+    let device_addr = 0x1_0000_0000u64;
+
+    let p = unsafe { stage(AX210, user_va, device_addr, region.len()) }.expect("fits");
+    assert_eq!(p.lmac.len(), 15);
+    assert_eq!(p.umac.len(), 16);
+    assert_eq!(p.virt.len(), 24);
+
+    // Every reported address is page-aligned and inside the region.
+    for &a in p.lmac.iter().chain(&p.umac).chain(&p.virt) {
+        assert_eq!(a % 4096, 0, "each chunk starts on a page");
+        assert!(a >= device_addr && a < device_addr + region.len() as u64);
+    }
+
+    // The first LMAC chunk sits at the region base and holds that section's
+    // bytes: a real copy, not just an address.
+    assert_eq!(p.lmac[0], device_addr);
+    let first = classify(AX210).lmac[0];
+    let off = (p.lmac[0] - device_addr) as usize;
+    assert_eq!(&region[off..off + first.data.len()], first.data);
+
+    // The second chunk is one page on (the 1656-byte header rounds up to 4096).
+    assert_eq!(p.umac.is_empty(), false);
+    assert!(p.staged_bytes > 1_600_000, "the whole ~1.6 MB image was staged");
+}
+
+#[test]
+fn stage_refuses_a_region_that_cannot_hold_the_images() {
+    let mut tiny = vec![0u8; 64 * 1024];
+    let user_va = tiny.as_mut_ptr() as u64;
+    let r = unsafe { stage(AX210, user_va, 0x1_0000_0000, tiny.len()) };
+    assert!(r.is_err(), "a region too small to hold the images is refused");
+}

--- a/userland/iwlwifi_proofs/src/lib.rs
+++ b/userland/iwlwifi_proofs/src/lib.rs
@@ -18,10 +18,10 @@ extern crate alloc;
 
 #[path = "../../capsule_driver_iwlwifi/src/constants/mod.rs"]
 pub mod constants;
-#[path = "../../capsule_driver_iwlwifi/src/regs.rs"]
-pub mod regs;
 #[path = "../../capsule_driver_iwlwifi/src/firmware/load.rs"]
 pub mod load;
+#[path = "../../capsule_driver_iwlwifi/src/regs.rs"]
+pub mod regs;
 
 // The 802.11 frame layer: pure IEEE encoding, no hardware, so it is checked
 // exactly rather than modeled. `src/dot11/mod.rs` pulls in the real files.
@@ -68,10 +68,26 @@ mod dot11_tests;
 #[cfg(test)]
 mod ccmp_tests;
 #[cfg(test)]
-mod supplicant_tests;
-#[cfg(test)]
-mod mlme_tests;
-#[cfg(test)]
 mod data_tests;
 #[path = "../../capsule_driver_iwlwifi/src/mlme/mod.rs"]
 pub mod mlme;
+#[cfg(test)]
+mod mlme_tests;
+#[cfg(test)]
+mod supplicant_tests;
+
+// The gen3 (AX210-class) firmware self-load: the context-information structure,
+// the peripheral-scratch control block, the image parser, and the boot
+// registers. Pure layout and parsing, checked byte-exact against the real
+// so-a0-gf-a0 image and the documented struct offsets.
+#[path = "../../capsule_driver_iwlwifi/src/firmware/gen3/mod.rs"]
+pub mod gen3;
+
+#[cfg(test)]
+mod dram_map_tests;
+#[cfg(test)]
+mod gen3_image_tests;
+#[cfg(test)]
+mod gen3_tests;
+#[cfg(test)]
+mod prph_scratch_tests;

--- a/userland/iwlwifi_proofs/src/prph_scratch_tests.rs
+++ b/userland/iwlwifi_proofs/src/prph_scratch_tests.rs
@@ -1,0 +1,129 @@
+// NONOS Operating System (AGPL-3.0-or-later)
+//! Ground-truth proofs for the gen3 peripheral-scratch structure. The layout is
+//! pinned to `struct iwl_prph_scratch` in Linux iwlwifi (pcie/iwl-context-info-v2.h)
+//! and the DRAM image map in pcie/iwl-context-info.h: a wrong field offset, a
+//! wrong struct size, or a byte written into the reserved gaps fails here. This
+//! is the block the context-information structure points at; if it is malformed
+//! the boot ROM reads garbage and the device never ALIVEs.
+
+use crate::gen3::prph_scratch::flags::CTRL_RB_SIZE_4K;
+use crate::gen3::prph_scratch::{DramImage, PrphScratch, MAX_DRAM_ENTRY, PRPH_SCRATCH_SIZE};
+
+fn rd16(b: &[u8], o: usize) -> u16 {
+    u16::from_le_bytes([b[o], b[o + 1]])
+}
+fn rd32(b: &[u8], o: usize) -> u32 {
+    u32::from_le_bytes([b[o], b[o + 1], b[o + 2], b[o + 3]])
+}
+fn rd64(b: &[u8], o: usize) -> u64 {
+    let mut v = [0u8; 8];
+    v.copy_from_slice(&b[o..o + 8]);
+    u64::from_le_bytes(v)
+}
+
+#[test]
+fn the_structure_is_1724_bytes() {
+    // ctrl_cfg (84) + fseq_override (4) + step_analog_params (4)
+    // + reserved[8] (32) + dram: umac[64] + lmac[64] + virtual[64] + fseq[8]
+    // = 84 + 40 + (512 + 512 + 512 + 64) = 1724.
+    assert_eq!(PRPH_SCRATCH_SIZE, 1724);
+    assert_eq!(MAX_DRAM_ENTRY, 64);
+}
+
+#[test]
+fn the_addresses_land_at_their_documented_offsets() {
+    let umac = [0x1000u64, 0x2000, 0x3000];
+    let lmac = [0xA000u64, 0xB000];
+    let virt = [0xC000u64];
+    let s = PrphScratch {
+        mac_id: 0x0034,
+        version: 0x0001,
+        control_flags: CTRL_RB_SIZE_4K,
+        control_flags_ext: 0,
+        pnvm_base: 0x1_2345_0000,
+        pnvm_size: 0x4000,
+        reduce_power_base: 0x9_8765_0000,
+        reduce_power_size: 0x0800,
+        free_rbd_addr: 0x5_5555_0000,
+        dram: DramImage { umac: &umac, lmac: &lmac, virt: &virt },
+    };
+    let mut buf = [0xEEu8; PRPH_SCRATCH_SIZE];
+    assert!(s.write(&mut buf));
+
+    // version @0: mac_id, version, size-in-dwords (84/4 = 21).
+    assert_eq!(rd16(&buf, 0), 0x0034);
+    assert_eq!(rd16(&buf, 2), 0x0001);
+    assert_eq!(rd16(&buf, 4), 21);
+
+    // control @8, control_ext @12.
+    assert_eq!(rd32(&buf, 8), CTRL_RB_SIZE_4K);
+    assert_eq!(rd32(&buf, 12), 0);
+
+    // pnvm_cfg @16: base then size.
+    assert_eq!(rd64(&buf, 16), 0x1_2345_0000);
+    assert_eq!(rd32(&buf, 24), 0x4000);
+
+    // rbd_cfg.free_rbd_addr @48.
+    assert_eq!(rd64(&buf, 48), 0x5_5555_0000);
+
+    // reduce_power_cfg @60: base then size.
+    assert_eq!(rd64(&buf, 60), 0x9_8765_0000);
+    assert_eq!(rd32(&buf, 68), 0x0800);
+
+    // dram image arrays: umac @124, lmac @124+512=636, virtual @636+512=1148.
+    assert_eq!(rd64(&buf, 124), 0x1000);
+    assert_eq!(rd64(&buf, 124 + 8), 0x2000);
+    assert_eq!(rd64(&buf, 124 + 16), 0x3000);
+    assert_eq!(rd64(&buf, 636), 0xA000);
+    assert_eq!(rd64(&buf, 636 + 8), 0xB000);
+    assert_eq!(rd64(&buf, 1148), 0xC000);
+}
+
+#[test]
+fn unused_dram_entries_and_the_hwm_gap_stay_zero() {
+    let umac = [0x1000u64];
+    let s = PrphScratch {
+        mac_id: 0,
+        version: 0,
+        control_flags: 0,
+        control_flags_ext: 0,
+        pnvm_base: 0,
+        pnvm_size: 0,
+        reduce_power_base: 0,
+        reduce_power_size: 0,
+        free_rbd_addr: 0,
+        dram: DramImage { umac: &umac, lmac: &[], virt: &[] },
+    };
+    let mut buf = [0xEEu8; PRPH_SCRATCH_SIZE];
+    assert!(s.write(&mut buf));
+    // The second umac slot was not supplied, so it must be zero, not 0xEE.
+    assert_eq!(rd64(&buf, 124 + 8), 0);
+    // The hwm_cfg block (@32..48) is not programmed and must be clear.
+    assert_eq!(rd64(&buf, 32), 0);
+    assert_eq!(rd32(&buf, 40), 0);
+    // The fseq_img array (last 64 bytes) stays zero: no external FSEQ image.
+    assert_eq!(rd64(&buf, PRPH_SCRATCH_SIZE - 8), 0);
+}
+
+#[test]
+fn an_oversized_image_or_short_buffer_is_refused() {
+    let too_many = [0u64; MAX_DRAM_ENTRY + 1];
+    let s = PrphScratch {
+        mac_id: 0,
+        version: 0,
+        control_flags: 0,
+        control_flags_ext: 0,
+        pnvm_base: 0,
+        pnvm_size: 0,
+        reduce_power_base: 0,
+        reduce_power_size: 0,
+        free_rbd_addr: 0,
+        dram: DramImage { umac: &too_many, lmac: &[], virt: &[] },
+    };
+    let mut buf = [0u8; PRPH_SCRATCH_SIZE];
+    assert!(!s.write(&mut buf), "an image with more than 64 chunks is refused");
+
+    let ok = PrphScratch { dram: DramImage { umac: &[], lmac: &[], virt: &[] }, ..s };
+    let mut small = [0u8; PRPH_SCRATCH_SIZE - 1];
+    assert!(!ok.write(&mut small), "a buffer below the struct size is refused");
+}


### PR DESCRIPTION
The AX210-class boot ROM reads a context-information structure from host memory
and, from it, a peripheral scratch block that holds the control flags, the
platform-NVM and reduce-power table addresses, the default receive-buffer ring,
and the firmware DRAM image map. The context info was already built but pointed
at a scratch block that was never assembled, so the gen3 self-load had nothing
to hand the ROM.

This adds that block with the packed 1724-byte layout from `iwl_prph_scratch`
(pcie/iwl-context-info-v2.h): an 84-byte control and config header (version,
control, pnvm, hwm, rbd, reduce-power, step), then fseq_override,
step_analog_params, eight reserved dwords, and the DRAM map of three 64-entry
image arrays plus an eight-entry fseq array. `write` refuses an image with more
than 64 chunks or a short buffer rather than truncating firmware silently.

The gen3 proofs existed in the tree but were never linked into the harness.
This wires them in and pins the new structure to its documented offsets and
total size, next to the context-info, boot-register, and image-parser proofs
that now run for the first time. All checked byte-exact against the documented
struct layout and the real so-a0-gf-a0 image; the register sequence that starts
the load still needs validation on Intel silicon.