### PR TITLE
tls: check basic constraints before trusting an issuer

### DIFF
--- a/userland/capsule_browser/src/browser/tls13/chain_walk.rs
+++ b/userland/capsule_browser/src/browser/tls13/chain_walk.rs
@@ -45,8 +45,12 @@ pub fn verify_chain(body: &[u8], host: &[u8], now: u64) -> bool {
         let Some(parent_spki) = super::cert_spki::cert_spki(parent) else {
             return false;
         };
+        // Every issuer must be a CA. Signature checks alone accept a chain in
+        // which an attacker's own leaf certificate signs a forgery. Shared
+        // with nonos_tls rather than reimplemented.
         if !super::verify_link::verify_link(child, parent_spki)
             || !super::cert_valid_now::cert_valid_now(parent, now)
+            || !nonos_tls::cert_is_ca(parent)
         {
             return false;
         }

--- a/userland/capsule_wallet_nonos/Cargo.lock
+++ b/userland/capsule_wallet_nonos/Cargo.lock
@@ -72,6 +72,13 @@ name = "nonos_qr"
 version = "0.3.0"
 
 [[package]]
+name = "nonos_tls"
+version = "0.2.0"
+dependencies = [
+ "nonos_userland_libc",
+]
+
+[[package]]
 name = "nonos_toolkit"
 version = "0.3.0"
 dependencies = [
@@ -94,6 +101,7 @@ dependencies = [
  "nonos_app_skeleton",
  "nonos_hd",
  "nonos_qr",
+ "nonos_tls",
  "nonos_userland_libc",
 ]
 

--- a/userland/capsule_wallet_nonos/Cargo.toml
+++ b/userland/capsule_wallet_nonos/Cargo.toml
@@ -16,6 +16,7 @@ nonos_libc = { package = "nonos_userland_libc", path = "../libc" }
 nonos_app_skeleton = { path = "../app_skeleton" }
 nonos_qr = { path = "../nonos_qr" }
 nonos_hd = { path = "../nonos_hd" }
+nonos_tls = { path = "../nonos_tls" }
 
 [profile.release]
 panic = "abort"

--- a/userland/capsule_wallet_nonos/src/wallet/tls13/chain_signatures.rs
+++ b/userland/capsule_wallet_nonos/src/wallet/tls13/chain_signatures.rs
@@ -21,6 +21,9 @@ pub fn chain_signatures(body: &[u8]) -> bool {
     let Some(leaf) = super::cert_at::cert_at(body, 0) else { return false };
     let Some(we1) = super::cert_at::cert_at(body, 1) else { return false };
     let Some(gts_r4) = super::cert_at::cert_at(body, 2) else { return false };
-    super::verify_leaf::verify_leaf(leaf, we1)
+    // Pinning the root is not enough on its own: any certificate that root
+    // issued would otherwise serve as an intermediate and sign a forged leaf.
+    nonos_tls::cert_is_ca(we1)
+        && super::verify_leaf::verify_leaf(leaf, we1)
         && super::verify_intermediate::verify_intermediate(we1, gts_r4)
 }

--- a/userland/nonos_tls/Cargo.lock
+++ b/userland/nonos_tls/Cargo.lock
@@ -22,14 +22,14 @@ dependencies = [
 
 [[package]]
 name = "nonos_tls"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nonos_userland_libc",
 ]
 
 [[package]]
 name = "nonos_userland_libc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "linked_list_allocator",
 ]

--- a/userland/nonos_tls/src/cert_ext.rs
+++ b/userland/nonos_tls/src/cert_ext.rs
@@ -1,0 +1,66 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Extensions live in [3] EXPLICIT at the end of TBSCertificate, after the
+// optional issuerUniqueID [1] and subjectUniqueID [2]. No extensions means a
+// v1 or v2 certificate, which cannot carry the constraints a CA is recognised
+// by, so the absent case is None rather than an empty list.
+pub fn extension_value<'a>(cert: &'a [u8], oid: &[u8]) -> Option<&'a [u8]> {
+    let (start, list_end) = extension_list(cert)?;
+    let mut cur = start;
+    while cur < list_end {
+        let (tag, inner, next) = super::der_tlv::der_tlv(cert, cur)?;
+        if tag != 0x30 {
+            return None;
+        }
+        if let Some(value) = super::cert_ext_entry::match_extension(cert, inner, next, oid) {
+            return Some(value);
+        }
+        cur = next;
+    }
+    None
+}
+
+fn extension_list(cert: &[u8]) -> Option<(usize, usize)> {
+    let (tag, val, end) = super::der_tlv::der_tlv(cert, 0)?;
+    if tag != 0x30 || end != cert.len() {
+        return None;
+    }
+    let (tag, tbs, tbs_end) = super::der_tlv::der_tlv(cert, val)?;
+    if tag != 0x30 {
+        return None;
+    }
+    let mut pos = tbs;
+    if cert.get(pos).copied() == Some(0xa0) {
+        pos = super::der_tlv::der_tlv(cert, pos)?.2;
+    }
+    // serial, signature, issuer, validity, subject, subjectPublicKeyInfo.
+    for _ in 0..6 {
+        pos = super::der_tlv::der_tlv(cert, pos)?.2;
+    }
+    while matches!(cert.get(pos).copied(), Some(0xa1) | Some(0xa2)) {
+        pos = super::der_tlv::der_tlv(cert, pos)?.2;
+    }
+    if cert.get(pos).copied() != Some(0xa3) || pos >= tbs_end {
+        return None;
+    }
+    let (_, outer, _) = super::der_tlv::der_tlv(cert, pos)?;
+    let (tag, start, list_end) = super::der_tlv::der_tlv(cert, outer)?;
+    if tag != 0x30 || list_end > tbs_end {
+        return None;
+    }
+    Some((start, list_end))
+}

--- a/userland/nonos_tls/src/cert_ext_entry.rs
+++ b/userland/nonos_tls/src/cert_ext_entry.rs
@@ -1,0 +1,39 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Extension ::= SEQUENCE { extnID OID, critical BOOLEAN DEFAULT FALSE,
+// extnValue OCTET STRING }. The default makes the flag commonly absent, so its
+// presence is tested rather than assumed.
+pub fn match_extension<'a>(
+    cert: &'a [u8],
+    inner: usize,
+    end: usize,
+    oid: &[u8],
+) -> Option<&'a [u8]> {
+    let (tag, oid_val, oid_end) = super::der_tlv::der_tlv(cert, inner)?;
+    if tag != 0x06 || oid_end > end || &cert[oid_val..oid_end] != oid {
+        return None;
+    }
+    let mut pos = oid_end;
+    if cert.get(pos).copied() == Some(0x01) {
+        pos = super::der_tlv::der_tlv(cert, pos)?.2;
+    }
+    let (tag, val, val_end) = super::der_tlv::der_tlv(cert, pos)?;
+    if tag != 0x04 || val_end > end {
+        return None;
+    }
+    Some(&cert[val..val_end])
+}

--- a/userland/nonos_tls/src/cert_is_ca.rs
+++ b/userland/nonos_tls/src/cert_is_ca.rs
@@ -1,0 +1,70 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// id-ce-basicConstraints, 2.5.29.19.
+const OID_BASIC_CONSTRAINTS: [u8; 3] = [0x55, 0x1d, 0x13];
+// id-ce-keyUsage, 2.5.29.15.
+const OID_KEY_USAGE: [u8; 3] = [0x55, 0x1d, 0x0f];
+// keyCertSign is bit 5, counted from the most significant bit of the first
+// content byte of the BIT STRING.
+const KEY_CERT_SIGN: u8 = 0x04;
+
+/// Whether this certificate is permitted to have issued the one below it.
+///
+/// Without this a leaf certificate for any domain an attacker controls can be
+/// presented as an intermediate and used to sign a certificate for any host,
+/// because every signature in such a chain verifies correctly. Absent or
+/// unparseable constraints deny.
+pub fn cert_is_ca(cert: &[u8]) -> bool {
+    let Some(value) = super::cert_ext::extension_value(cert, &OID_BASIC_CONSTRAINTS) else {
+        return false;
+    };
+    if !basic_constraints_ca(value) {
+        return false;
+    }
+    key_usage_allows_signing(cert)
+}
+
+// BasicConstraints ::= SEQUENCE { cA BOOLEAN DEFAULT FALSE, ... }. The default
+// means an empty sequence is a valid encoding of "not a CA".
+fn basic_constraints_ca(value: &[u8]) -> bool {
+    let Some((tag, inner, end)) = super::der_tlv::der_tlv(value, 0) else {
+        return false;
+    };
+    if tag != 0x30 || inner >= end {
+        return false;
+    }
+    let Some((tag, val, val_end)) = super::der_tlv::der_tlv(value, inner) else {
+        return false;
+    };
+    tag == 0x01 && val_end == val + 1 && value[val] != 0
+}
+
+// KeyUsage is optional. When a certificate carries one it is binding, so a CA
+// that did not assert keyCertSign is refused.
+fn key_usage_allows_signing(cert: &[u8]) -> bool {
+    let Some(value) = super::cert_ext::extension_value(cert, &OID_KEY_USAGE) else {
+        return true;
+    };
+    let Some((tag, val, end)) = super::der_tlv::der_tlv(value, 0) else {
+        return false;
+    };
+    // First content byte counts the unused trailing bits; the flags follow.
+    if tag != 0x03 || end <= val + 1 {
+        return false;
+    }
+    value[val + 1] & KEY_CERT_SIGN != 0
+}

--- a/userland/nonos_tls/src/chain_walk.rs
+++ b/userland/nonos_tls/src/chain_walk.rs
@@ -45,8 +45,11 @@ pub fn verify_chain(body: &[u8], host: &[u8], now: u64) -> bool {
         let Some(parent_spki) = super::cert_spki::cert_spki(parent) else {
             return false;
         };
+        // Every issuer must be a CA. Signature checks alone accept a chain in
+        // which an attacker's own leaf certificate signs a forgery.
         if !super::verify_link::verify_link(child, parent_spki)
             || !super::cert_valid_now::cert_valid_now(parent, now)
+            || !super::cert_is_ca::cert_is_ca(parent)
         {
             return false;
         }

--- a/userland/nonos_tls/src/lib.rs
+++ b/userland/nonos_tls/src/lib.rs
@@ -35,6 +35,9 @@ mod application_write;
 mod cert_at;
 mod cert_count;
 mod cert_dns_match;
+mod cert_ext;
+mod cert_ext_entry;
+mod cert_is_ca;
 mod cert_issuer;
 mod cert_sig_alg;
 mod cert_signature;
@@ -90,6 +93,10 @@ mod verify_p384;
 mod verify_rsa;
 
 pub use application_plaintext::{application_plaintext, application_plaintext_cached};
+// Exported so the browser's own chain walk enforces the same issuer rule from
+// the same code. A second copy is how one of them gets fixed and the other
+// does not.
+pub use cert_is_ca::cert_is_ca;
 pub use application_request::application_request;
 pub use application_write::application_write;
 pub use client_flight::client_flight;


### PR DESCRIPTION
The chain walk verified every signature in the chain and never asked whether the issuer was permitted to be one.

Any certificate signed by a trusted CA could therefore act as a CA. A leaf issued for one host could sign a certificate for any other host, and the chain still verified end to end. This is the same class of flaw that has shipped in major TLS stacks more than once, and it compiles without a warning because nothing about it is syntactically wrong.

`cert_is_ca` parses the basic constraints extension and requires `cA` to be true for every certificate used as an issuer. An absent extension is not a CA, which is what the specification says and the safe reading either way.

The walk had been copied into three places, so `nonos_tls`, the browser and the wallet are all fixed here rather than one of them and a note to do the others later.

## Testing

Not booted. Found by reading, fixed by reading. A negative test with a leaf signed chain would be worth adding before this is trusted in anger.

Independent of #442, #444 and #445.