### PR TITLE
sdk: make an application declare what it may do

### DIFF
--- a/mk/00-config.mk
+++ b/mk/00-config.mk
@@ -56,6 +56,10 @@ TOOLCHAIN := nightly-2026-01-16
 CARGO     := $(HOME)/.cargo/bin/cargo
 RUSTUP    := $(HOME)/.cargo/bin/rustup
 NONOS_PYTHON ?= /usr/bin/python3
+# Compares a capsule's `.nonos.caps` section against the capability set its
+# manifest is about to be signed for. Runs before every manifest signature, so
+# a manifest granting powers the source never declared is never signed.
+NONOS_CAPS_CHECK ?= $(NONOS_PYTHON) scripts/check_declared_caps.py
 NONOS_BENCH_OUT ?=
 NONOS_BENCH_BUILD_CMD ?= make nonos-mk-verify-fast
 NONOS_BENCH_SKIP_BUILD ?= 0

--- a/scripts/check_declared_caps.py
+++ b/scripts/check_declared_caps.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# NONOS Operating System
+# Copyright (C) 2026 NONOS Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Refuse to sign a capsule whose manifest claims different powers than its
+source declared.
+
+The source writes its capability set into a `.nonos.caps` section. The manifest
+carries a number a human typed into `Capsule.mk`. Nothing previously compared
+them, so a capsule could be signed for powers its code never asked for, or ask
+for powers the manifest never granted. Both are silent until something fails at
+runtime, and for a capsule written by an agent rather than a person the
+manifest is the only thing standing between a user and whatever it decided to
+do.
+
+ELF is parsed here rather than shelled out to `nm` or `readelf`, because those
+report symbols and release builds strip them.
+"""
+
+import argparse
+import struct
+import sys
+from pathlib import Path
+from typing import Optional
+
+SECTION = ".nonos.caps"
+
+
+def read_section(path: Path, want: str) -> Optional[bytes]:
+    """Return the contents of a named section of a 64-bit little-endian ELF."""
+    blob = path.read_bytes()
+    if len(blob) < 64 or blob[:4] != b"\x7fELF":
+        raise ValueError(f"{path} is not an ELF file")
+    if blob[4] != 2 or blob[5] != 1:
+        raise ValueError(f"{path} is not 64-bit little-endian ELF")
+
+    e_shoff, = struct.unpack_from("<Q", blob, 0x28)
+    e_shentsize, e_shnum, e_shstrndx = struct.unpack_from("<HHH", blob, 0x3A)
+    if e_shoff == 0 or e_shnum == 0:
+        raise ValueError(f"{path} has no section table")
+
+    def section(i):
+        off = e_shoff + i * e_shentsize
+        name, _type, _flags, _addr, offset, size = struct.unpack_from("<IIQQQQ", blob, off)
+        return name, offset, size
+
+    _, strtab_off, strtab_size = section(e_shstrndx)
+    strtab = blob[strtab_off:strtab_off + strtab_size]
+
+    for i in range(e_shnum):
+        name_off, offset, size = section(i)
+        end = strtab.find(b"\0", name_off)
+        if strtab[name_off:end].decode("ascii", "replace") == want:
+            return blob[offset:offset + size]
+    return None
+
+
+def parse_caps(text: str) -> int:
+    """Accept 0x-prefixed hex or decimal, the two forms Capsule.mk uses."""
+    text = text.strip()
+    return int(text, 16) if text.lower().startswith("0x") else int(text, 10)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("binary", type=Path, help="built capsule ELF")
+    ap.add_argument("--manifest-caps", required=True,
+                    help="CAPSULE_REQUIRED_CAPS from Capsule.mk")
+    ap.add_argument("--allow-missing", action="store_true",
+                    help="pass capsules built without the SDK, which have no section")
+    args = ap.parse_args()
+
+    try:
+        raw = read_section(args.binary, SECTION)
+    except ValueError as e:
+        print(f"check-caps: {e}", file=sys.stderr)
+        return 2
+
+    if raw is None:
+        if args.allow_missing:
+            print(f"check-caps: {args.binary.name}: no {SECTION}, not an SDK capsule")
+            return 0
+        print(f"check-caps: {args.binary.name}: no {SECTION} section", file=sys.stderr)
+        print("  built without sdk_main!, or the section was discarded by the linker",
+              file=sys.stderr)
+        return 1
+
+    if len(raw) < 8:
+        print(f"check-caps: {SECTION} is {len(raw)} bytes, expected at least 8",
+              file=sys.stderr)
+        return 1
+
+    declared, = struct.unpack_from("<Q", raw, 0)
+    manifest = parse_caps(args.manifest_caps)
+
+    if declared == manifest:
+        print(f"check-caps: {args.binary.name}: 0x{declared:X} declared and granted")
+        return 0
+
+    # Report the difference in both directions. Which way it points changes what
+    # the developer has to fix: extra manifest bits are an over-grant the kernel
+    # will honour, extra source bits are a program that will fail at runtime.
+    print(f"check-caps: {args.binary.name}: MANIFEST DISAGREES WITH SOURCE", file=sys.stderr)
+    print(f"  source declares : 0x{declared:X}", file=sys.stderr)
+    print(f"  manifest grants : 0x{manifest:X}", file=sys.stderr)
+    over = manifest & ~declared
+    under = declared & ~manifest
+    if over:
+        print(f"  granted but not declared : 0x{over:X}  (over-grant, kernel would honour it)",
+              file=sys.stderr)
+    if under:
+        print(f"  declared but not granted : 0x{under:X}  (app would fail at runtime)",
+              file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/userland/sdk/examples/appkit_demo/Cargo.lock
+++ b/userland/sdk/examples/appkit_demo/Cargo.lock
@@ -22,11 +22,11 @@ dependencies = [
 
 [[package]]
 name = "nonos-abi"
-version = "0.1.0"
+version = "0.3.0"
 
 [[package]]
 name = "nonos-alloc"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "linked_list_allocator",
  "nonos-abi",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "nonos-app"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nonos-abi",
  "nonos-desktop",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "nonos-appkit"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nonos-abi",
  "nonos-font",
@@ -55,11 +55,11 @@ dependencies = [
 
 [[package]]
 name = "nonos-cap"
-version = "0.1.0"
+version = "0.3.0"
 
 [[package]]
 name = "nonos-desktop"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nonos-abi",
  "nonos-ipc",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "nonos-example-appkit"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nonos-appkit",
  "nonos-sdk",
@@ -76,32 +76,32 @@ dependencies = [
 
 [[package]]
 name = "nonos-font"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "nonos-ipc"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "nonos-abi",
 ]
 
 [[package]]
 name = "nonos-log"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "nonos-abi",
 ]
 
 [[package]]
 name = "nonos-panic"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "nonos-abi",
 ]
 
 [[package]]
 name = "nonos-prelude"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nonos-app",
  "nonos-runtime",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "nonos-runtime"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "nonos-abi",
  "nonos-alloc",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "nonos-sdk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nonos-cap",
  "nonos-prelude",
@@ -135,21 +135,21 @@ dependencies = [
 
 [[package]]
 name = "nonos-service"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "nonos-abi",
 ]
 
 [[package]]
 name = "nonos-surface"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "nonos-abi",
 ]
 
 [[package]]
 name = "nonos-ui"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nonos-abi",
  "nonos-font",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "nonos-window"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nonos-surface",
 ]

--- a/userland/sdk/examples/hello_nonos/Cargo.lock
+++ b/userland/sdk/examples/hello_nonos/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "hello-nonos"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nonos-sdk",
 ]
@@ -29,11 +29,11 @@ dependencies = [
 
 [[package]]
 name = "nonos-abi"
-version = "0.1.0"
+version = "0.3.0"
 
 [[package]]
 name = "nonos-alloc"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "linked_list_allocator",
  "nonos-abi",
@@ -41,45 +41,57 @@ dependencies = [
 
 [[package]]
 name = "nonos-app"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
+ "nonos-abi",
+ "nonos-desktop",
  "nonos-runtime",
+ "nonos-surface",
  "nonos-ui",
  "nonos-window",
 ]
 
 [[package]]
 name = "nonos-cap"
-version = "0.1.0"
+version = "0.3.0"
+
+[[package]]
+name = "nonos-desktop"
+version = "0.2.0"
+dependencies = [
+ "nonos-abi",
+ "nonos-ipc",
+ "nonos-service",
+]
 
 [[package]]
 name = "nonos-font"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "nonos-ipc"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "nonos-abi",
 ]
 
 [[package]]
 name = "nonos-log"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "nonos-abi",
 ]
 
 [[package]]
 name = "nonos-panic"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "nonos-abi",
 ]
 
 [[package]]
 name = "nonos-prelude"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nonos-app",
  "nonos-runtime",
@@ -89,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "nonos-runtime"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "nonos-abi",
  "nonos-alloc",
@@ -104,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "nonos-sdk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nonos-cap",
  "nonos-prelude",
@@ -113,28 +125,29 @@ dependencies = [
 
 [[package]]
 name = "nonos-service"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "nonos-abi",
 ]
 
 [[package]]
 name = "nonos-surface"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "nonos-abi",
 ]
 
 [[package]]
 name = "nonos-ui"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
+ "nonos-abi",
  "nonos-font",
 ]
 
 [[package]]
 name = "nonos-window"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nonos-surface",
 ]

--- a/userland/sdk/examples/hello_nonos/src/main.rs
+++ b/userland/sdk/examples/hello_nonos/src/main.rs
@@ -23,4 +23,5 @@ fn app() {
     let _ = App::new("Hello").window().show();
 }
 
-sdk_main!(app);
+// It opens a window, so it asks for a window. Nothing else.
+sdk_main!(app, caps: [WINDOW]);

--- a/userland/sdk/nonos_sdk/src/caps/base.rs
+++ b/userland/sdk/nonos_sdk/src/caps/base.rs
@@ -14,25 +14,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![no_std]
-#![no_main]
+use nonos_cap::{CAP_CORE_EXEC, CAP_MEMORY};
 
-use nonos_appkit::{Button, Label, Panel, Theme};
-use nonos_sdk::prelude::*;
-
-fn app() {
-    let theme = Theme::dark();
-    let root = Panel::new()
-        .label(Label::new(Rect { x: 16, y: 16, w: 300, h: 8 }, "NONOS App Kit", theme.foreground))
-        .button(Button::new(
-            Rect { x: 16, y: 40, w: 120, h: 28 },
-            "Launch",
-            theme.button_bg,
-            theme.button_fg,
-            theme.accent,
-        ));
-    App::new("App Kit Demo").size(480, 320).background(theme.background).run(root);
-}
-
-// Widgets and a window; it needs nothing else.
-sdk_main!(app, caps: [WINDOW]);
+/// What every program needs to exist at all: the right to run, and memory to
+/// run in.
+///
+/// This is the floor, not a default set of conveniences. An app that declares
+/// nothing gets exactly this and can do nothing else — it cannot draw, reach
+/// the network, or read a file. Everything beyond it has to be asked for by
+/// name, which is the point: what an app can do should be visible in its
+/// source, in its manifest, and to the person installing it.
+pub const BASE: u64 = CAP_CORE_EXEC | CAP_MEMORY;

--- a/userland/sdk/nonos_sdk/src/caps/groups.rs
+++ b/userland/sdk/nonos_sdk/src/caps/groups.rs
@@ -1,0 +1,63 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use nonos_cap::{
+    CAP_CRYPTO, CAP_DEBUG, CAP_ENROL_DEV_ROOT, CAP_FILESYSTEM, CAP_GRAPHICS_DISPLAY_QUERY,
+    CAP_GRAPHICS_PRESENT, CAP_GRAPHICS_SURFACE_CREATE, CAP_GRAPHICS_SURFACE_MAP, CAP_IPC,
+    CAP_NETWORK, CAP_REGISTER_SERVICE,
+};
+
+// Groups are stated as intent, not as bits. A developer knows they want a
+// window; they should not have to know that a window is four separate
+// permissions, or which four. The kernel still enforces the bits, so the
+// grouping costs nothing in precision and buys a declaration a reviewer can
+// read at a glance.
+
+/// Draw to the screen and own a window.
+pub const WINDOW: u64 = CAP_GRAPHICS_DISPLAY_QUERY
+    | CAP_GRAPHICS_SURFACE_CREATE
+    | CAP_GRAPHICS_SURFACE_MAP
+    | CAP_GRAPHICS_PRESENT;
+
+/// Reach the network. Whether that traffic is forced through the mixnet is a
+/// separate matter the system decides, not the app.
+pub const NETWORK: u64 = CAP_NETWORK;
+
+/// Read and write files.
+pub const STORAGE: u64 = CAP_FILESYSTEM;
+
+/// Use the kernel's cryptographic services, including the random source.
+pub const CRYPTO: u64 = CAP_CRYPTO;
+
+/// Talk to other capsules by message.
+pub const IPC: u64 = CAP_IPC;
+
+/// Answer on a named endpoint, so other capsules can find this one. Implies
+/// IPC, because a service nobody can message is not a service.
+pub const SERVICE: u64 = CAP_REGISTER_SERVICE | CAP_IPC;
+
+/// Write to the boot log. Useful while developing, and worth removing before
+/// publishing: a shipped app that narrates itself to the console is leaking
+/// whatever it narrates.
+pub const DEBUG: u64 = CAP_DEBUG;
+
+/// Ask the machine to trust a signing root, so software built here can run
+/// here. Held by a build capsule and nothing else.
+///
+/// Declaring it does not grant the power to approve: enrolment needs a code
+/// the kernel prints to a console no capsule can read. This bit only buys the
+/// right to ask.
+pub const BUILD_TOOLING: u64 = CAP_ENROL_DEV_ROOT;

--- a/userland/sdk/nonos_sdk/src/caps/mod.rs
+++ b/userland/sdk/nonos_sdk/src/caps/mod.rs
@@ -14,15 +14,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use nonos_cap::{
-    CAP_CORE_EXEC, CAP_DEBUG, CAP_GRAPHICS_DISPLAY_QUERY, CAP_GRAPHICS_PRESENT,
-    CAP_GRAPHICS_SURFACE_CREATE, CAP_GRAPHICS_SURFACE_MAP, CAP_MEMORY,
-};
+//! What an app is allowed to do, declared by the app itself.
+//!
+//! Every capability an app holds is written in its own source, expands into
+//! the manifest it is signed and proved against, and is enforced by the
+//! kernel at spawn. There is no set of powers an app gets for free beyond
+//! `BASE`, and nothing it can acquire later.
 
-pub const SDK_CAPS: u64 = CAP_CORE_EXEC
-    | CAP_MEMORY
-    | CAP_DEBUG
-    | CAP_GRAPHICS_DISPLAY_QUERY
-    | CAP_GRAPHICS_SURFACE_CREATE
-    | CAP_GRAPHICS_SURFACE_MAP
-    | CAP_GRAPHICS_PRESENT;
+mod base;
+mod groups;
+
+pub use base::BASE;
+pub use groups::{BUILD_TOOLING, CRYPTO, DEBUG, IPC, NETWORK, SERVICE, STORAGE, WINDOW};

--- a/userland/sdk/nonos_sdk/src/lib.rs
+++ b/userland/sdk/nonos_sdk/src/lib.rs
@@ -16,9 +16,8 @@
 
 #![no_std]
 
-mod caps;
+pub mod caps;
 mod macros;
 pub mod prelude;
 
-pub use caps::SDK_CAPS;
 pub use nonos_runtime::run as __run;

--- a/userland/sdk/nonos_sdk/src/macros.rs
+++ b/userland/sdk/nonos_sdk/src/macros.rs
@@ -14,12 +14,42 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+/// Declare an app's entry point and everything it is permitted to do.
+///
+/// ```ignore
+/// sdk_main!(app);                            // can run, and nothing else
+/// sdk_main!(app, caps: [WINDOW]);            // and can draw
+/// sdk_main!(app, caps: [WINDOW, NETWORK]);   // and can reach the network
+/// ```
+///
+/// The list is not advice to the runtime. It is written into a `.nonos.caps`
+/// section of the binary, and the build refuses to sign a capsule whose
+/// manifest disagrees with it. So what the source says an app may do, what the
+/// manifest is signed for, and what the kernel installs are one fact checked
+/// in one place rather than three numbers that drift.
+///
+/// A section rather than a symbol because release builds strip symbols, and a
+/// declaration that vanishes under `--strip-all` is worse than none: it would
+/// verify in development and silently stop being checked in the build that
+/// ships.
+///
+/// Omitting the list is not a shortcut to a working app. It declares that the
+/// app needs nothing, and it will be held to that.
 #[macro_export]
 macro_rules! sdk_main {
     ($entry:path) => {
+        $crate::sdk_main!($entry, caps: []);
+    };
+    ($entry:path, caps: [$($group:ident),* $(,)?]) => {
+        #[no_mangle]
+        #[used]
+        #[link_section = ".nonos.caps"]
+        pub static NONOS_DECLARED_CAPS: u64 =
+            $crate::caps::BASE $(| $crate::caps::$group)*;
+
         #[no_mangle]
         pub extern "C" fn _start() -> ! {
-            $crate::__run($crate::SDK_CAPS, $entry)
+            $crate::__run(NONOS_DECLARED_CAPS, $entry)
         }
     };
 }

--- a/userland/sdk/nonos_sdk/src/prelude.rs
+++ b/userland/sdk/nonos_sdk/src/prelude.rs
@@ -15,5 +15,4 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 pub use crate::sdk_main;
-pub use crate::SDK_CAPS;
 pub use nonos_prelude::*;


### PR DESCRIPTION
Stacked on #442.

`sdk_main!` took no capabilities. Every application built with the SDK received the same blanket set, so the manifest was the only statement of what a capsule could do, and nothing compared it to the code.

An application now declares once, in its own source, and the declaration is the API:

    sdk_main!(app, caps: [WINDOW, NETWORK]);

Capabilities are named as intent rather than as bits. A developer knows they want a window; they should not have to know that a window is four separate permissions, or which four. The kernel still enforces bits, so nothing is lost in precision and everything is gained in whether a reviewer can read it.

An application that asks for nothing receives execute and allocate memory. It cannot draw, open a file, reach the network, or write to the log. Nothing arrives that was not named.

## Why a section and not a symbol

The declaration is emitted into `.nonos.caps`. Release builds link with `--strip-all`, so a symbol would verify in development and silently stop being checked in the build that actually ships, which is worse than no check because you believe in it.

`scripts/check_declared_caps.py` reads the section and compares it against the manifest. The build rule that calls it is NON-OS/nonos-mk#7, which has to merge for the gate to run.

## Why this matters more than it used to

Software is increasingly written by models. The industry answer is to review generated code before running it, which does not scale and mostly does not happen.

A model can write the program. It cannot grant that program a permission the author did not write down, because the declaration is in the source, the section is compiled from it, the build refuses to sign a manifest that disagrees, and the kernel installs from the verified manifest and nothing else. That holds whether the model is careful, careless or adversarial.

## Testing

Not booted. The gate itself is demonstrable in about thirty seconds with `scripts/demo_caps_gate.py`, and it is considerably more convincing when it fails than when it passes.