### PR TITLE
abi: publish the syscalls the kernel actually dispatches

### DIFF
--- a/abi/syscalls.toml
+++ b/abi/syscalls.toml
@@ -46,6 +46,48 @@ max_caps        = 1024
 max_devices     = 256
 
 [numbers]
+APPS = 0x53505041
+CDAD = 0x44414443
+CEAD = 0x44414543
+CEDP = 0x50444543
+CEDS = 0x53444543
+CHKF = 0x464B4843
+CHMC = 0x434D4843
+CKEC = 0x43454B43
+CSKS = 0x534B5343
+CSPB = 0x42505343
+CXPK = 0x4B505843
+CXSH = 0x48535843
+MAST = 0x5453414D
+MBAT = 0x5441424D
+MCLD = 0x444C434D
+MCVF = 0x4656434D
+MFTK = 0x4B54464D
+MFTW = 0x5754464D
+MGPD = 0x4450474D
+MIEW = 0x5745494D
+MIRW = 0x5752494D
+MIRY = 0x5952494D
+MKAR = 0x52414B4D
+MKIL = 0x4C494B4D
+MMON = 0x4E4F4D4D
+MOUT = 0x54554F4D
+MPCR = 0x5243504D
+MPCW = 0x5743504D
+MPIN = 0x4E49504D
+MPST = 0x5453504D
+MSOW = 0x574F534D
+MSPI = 0x4950534D
+MSRD = 0x4452534D
+MSTB = 0x4254534D
+MSVR = 0x5256534D
+MSWR = 0x5257534D
+MTAD = 0x4441544D
+MTMS = 0x534D544D
+MTRN = 0x4E52544D
+MTRT = 0x5452544D
+MTSP = 0x5053544D
+MWAT = 0x5441574D
 CRND = 0x444E5243
 CHSH = 0x48534843
 CENC = 0x434E4543
@@ -378,4 +420,254 @@ ret  = {type="i64"}
 nr   = 0x4445494D
 caps = ["IPC"]
 args = [{name="buf",type="u8*",dir="out"},{name="cap",type="usize",dir="in"},{name="count_out",type="u32*",dir="out"}]
+ret  = {type="i64"}
+
+[desc.APPS]
+nr   = 0x53505041
+caps = ["valid_token"]
+args = [{name="field_id",type="u64",dir="in"},{name="kind",type="u64",dir="in"},{name="value_ptr",type="u64",dir="in"},{name="value_len",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.CDAD]
+nr   = 0x44414443
+caps = ["valid_token"]
+args = [{name="algo",type="u64",dir="in"},{name="key_ptr",type="u64",dir="in"},{name="nonce_ptr",type="u64",dir="in"},{name="frame_ptr",type="u64",dir="in"},{name="frame_len",type="u64",dir="in"},{name="plaintext_ptr",type="u64",dir="out"}]
+ret  = {type="i64"}
+
+[desc.CEAD]
+nr   = 0x44414543
+caps = ["valid_token"]
+args = [{name="algo",type="u64",dir="in"},{name="key_ptr",type="u64",dir="in"},{name="nonce_ptr",type="u64",dir="in"},{name="frame_ptr",type="u64",dir="in"},{name="frame_len",type="u64",dir="in"},{name="ciphertext_ptr",type="u64",dir="out"}]
+ret  = {type="i64"}
+
+[desc.CEDP]
+nr   = 0x50444543
+caps = ["valid_token"]
+args = [{name="seed_ptr",type="u64",dir="in"},{name="out",type="u64",dir="out"}]
+ret  = {type="i64"}
+
+[desc.CEDS]
+nr   = 0x53444543
+caps = ["valid_token"]
+args = [{name="seed_ptr",type="u64",dir="in"},{name="msg_ptr",type="u64",dir="in"},{name="msg_len",type="u64",dir="in"},{name="out",type="u64",dir="out"}]
+ret  = {type="i64"}
+
+[desc.CHKF]
+nr   = 0x464B4843
+caps = ["valid_token"]
+args = [{name="frame_ptr",type="u64",dir="in"},{name="frame_len",type="u64",dir="in"},{name="out_ptr",type="u64",dir="out"},{name="out_len",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.CHMC]
+nr   = 0x434D4843
+caps = ["valid_token"]
+args = [{name="key_ptr",type="u64",dir="in"},{name="key_len",type="u64",dir="in"},{name="data_ptr",type="u64",dir="in"},{name="data_len",type="u64",dir="in"},{name="out_ptr",type="u64",dir="out"}]
+ret  = {type="i64"}
+
+[desc.CKEC]
+nr   = 0x43454B43
+caps = ["valid_token"]
+args = [{name="data",type="u64",dir="in"},{name="len",type="u64",dir="in"},{name="out",type="u64",dir="out"},{name="out_len",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.CSKS]
+nr   = 0x534B5343
+caps = ["valid_token"]
+args = [{name="sk_ptr",type="u64",dir="in"},{name="digest_ptr",type="u64",dir="in"},{name="out",type="u64",dir="out"}]
+ret  = {type="i64"}
+
+[desc.CSPB]
+nr   = 0x42505343
+caps = ["valid_token"]
+args = [{name="sk_ptr",type="u64",dir="in"},{name="out",type="u64",dir="out"}]
+ret  = {type="i64"}
+
+[desc.CXPK]
+nr   = 0x4B505843
+caps = ["valid_token"]
+args = [{name="private_ptr",type="u64",dir="in"},{name="out_ptr",type="u64",dir="out"}]
+ret  = {type="i64"}
+
+[desc.CXSH]
+nr   = 0x48535843
+caps = ["valid_token"]
+args = [{name="private_ptr",type="u64",dir="in"},{name="public_ptr",type="u64",dir="in"},{name="out_ptr",type="u64",dir="out"}]
+ret  = {type="i64"}
+[desc.MAST]
+nr   = 0x5453414D
+caps = ["valid_token"]
+args = [{name="out_ptr",type="u64",dir="out"}]
+ret  = {type="i64"}
+
+[desc.MBAT]
+nr   = 0x5441424D
+caps = ["valid_token"]
+args = []
+ret  = {type="i64"}
+
+[desc.MCLD]
+nr   = 0x444C434D
+caps = ["valid_token"]
+args = [{name="req_ptr",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MCVF]
+nr   = 0x4656434D
+caps = ["valid_token"]
+args = [{name="req_ptr",type="u64",dir="in"},{name="out_ptr",type="u64",dir="out"}]
+ret  = {type="i64"}
+[desc.MFTK]
+nr   = 0x4B54464D
+caps = ["valid_token"]
+args = [{name="vaddr",type="u64",dir="in"},{name="count",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MFTW]
+nr   = 0x5754464D
+caps = ["valid_token"]
+args = [{name="vaddr",type="u64",dir="in"},{name="expected",type="u32",dir="in"},{name="timeout_ms",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MGPD]
+nr   = 0x4450474D
+caps = ["valid_token"]
+args = []
+ret  = {type="i64"}
+
+[desc.MIEW]
+nr   = 0x5745494D
+caps = ["valid_token"]
+args = [{name="last_seq",type="u64",dir="in"},{name="timeout_ms",type="u64",dir="in"},{name="out_ptr",type="u64",dir="out"}]
+ret  = {type="i64"}
+
+[desc.MIRW]
+nr   = 0x5752494D
+caps = ["valid_token"]
+args = [{name="grant_id",type="u64",dir="in"},{name="last_seq",type="u64",dir="in"},{name="timeout_ms",type="u64",dir="in"},{name="out_ptr",type="u64",dir="out"}]
+ret  = {type="i64"}
+
+[desc.MIRY]
+nr   = 0x5952494D
+caps = ["valid_token"]
+args = [{name="dest_pid",type="u64",dir="in"},{name="buf",type="u64",dir="out"},{name="len",type="usize",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MKAR]
+nr   = 0x52414B4D
+caps = ["valid_token"]
+args = [{name="buf",type="u64",dir="out"},{name="len",type="usize",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MKIL]
+nr   = 0x4C494B4D
+caps = ["valid_token"]
+args = [{name="pid",type="u64",dir="in"},{name="sig",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MMON]
+nr   = 0x4E4F4D4D
+caps = ["valid_token"]
+args = []
+ret  = {type="i64"}
+
+[desc.MOUT]
+nr   = 0x54554F4D
+caps = ["valid_token"]
+args = [{name="pid",type="u64",dir="in"},{name="buf_ptr",type="u64",dir="out"},{name="buf_len",type="usize",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MPCR]
+nr   = 0x5243504D
+caps = ["valid_token"]
+args = [{name="device_id",type="u64",dir="in"},{name="claim_epoch",type="u64",dir="in"},{name="offset",type="u32",dir="in"},{name="width",type="u32",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MPCW]
+nr   = 0x5743504D
+caps = ["valid_token"]
+args = [{name="device_id",type="u64",dir="in"},{name="claim_epoch",type="u64",dir="in"},{name="offset",type="u32",dir="in"},{name="value",type="u32",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MPIN]
+nr   = 0x4E49504D
+caps = ["valid_token"]
+args = [{name="pid",type="u64",dir="in"},{name="buf_ptr",type="u64",dir="out"},{name="buf_len",type="usize",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MPST]
+nr   = 0x5453504D
+caps = ["valid_token"]
+args = [{name="buf_ptr",type="u64",dir="out"},{name="max_entries",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MSOW]
+nr   = 0x574F534D
+caps = ["valid_token"]
+args = [{name="user_ptr",type="u64",dir="in"},{name="len",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MSPI]
+nr   = 0x4950534D
+caps = ["valid_token"]
+args = [{name="name_ptr",type="u64",dir="in"},{name="name_len",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MSRD]
+nr   = 0x4452534D
+caps = ["valid_token"]
+args = [{name="buf_ptr",type="u64",dir="out"},{name="buf_len",type="usize",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MSTB]
+nr   = 0x4254534D
+caps = ["valid_token"]
+args = [{name="base",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MSVR]
+nr   = 0x5256534D
+caps = ["valid_token"]
+args = [{name="name_ptr",type="u64",dir="in"},{name="name_len",type="usize",dir="in"},{name="port",type="u32",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MSWR]
+nr   = 0x5257534D
+caps = ["valid_token"]
+args = [{name="lba",type="u64",dir="in"},{name="user_ptr",type="u64",dir="in"},{name="len",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MTAD]
+nr   = 0x4441544D
+caps = ["valid_token"]
+args = [{name="correct_ms",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MTMS]
+nr   = 0x534D544D
+caps = ["valid_token"]
+args = []
+ret  = {type="i64"}
+
+[desc.MTRN]
+nr   = 0x4E52544D
+caps = ["valid_token"]
+args = [{name="name_ptr",type="u64",dir="in"},{name="name_len",type="u64",dir="in"},{name="argv_ptr",type="u64",dir="in"},{name="argv_len",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MTRT]
+nr   = 0x5452544D
+caps = ["valid_token"]
+args = [{name="out_ptr",type="u64",dir="out"}]
+ret  = {type="i64"}
+
+[desc.MTSP]
+nr   = 0x5053544D
+caps = ["valid_token"]
+args = [{name="entry",type="u64",dir="in"},{name="stack",type="u64",dir="in"}]
+ret  = {type="i64"}
+
+[desc.MWAT]
+nr   = 0x5441574D
+caps = ["valid_token"]
+args = [{name="pid",type="u64",dir="in"},{name="timeout_ms",type="u64",dir="in"}]
 ret  = {type="i64"}

--- a/abi/syscalls.toml
+++ b/abi/syscalls.toml
@@ -48,30 +48,14 @@ max_devices     = 256
 [numbers]
 CRND = 0x444E5243
 CHSH = 0x48534843
-CSGN = 0x4E475343
-CVRF = 0x46525643
 CENC = 0x434E4543
 CDEC = 0x43454443
-CKGN = 0x4E474B43
-CZKP = 0x504B5A43
-CZKV = 0x564B5A43
 CEDV = 0x56444543
-
-DLOG = 0x474F4C44
-DTRC = 0x43525444
 
 ARBT = 0x54425241
 ASDN = 0x4E445341
-AMOD = 0x444F4D41
 
 GDIM = 0x4D494447
-GSCR = 0x52435347
-GSDS = 0x53445347
-GSMP = 0x504D5347
-GPRF = 0x46525047
-GPRR = 0x52525047
-GDLS = 0x534C4447
-GCUR = 0x52554347
 
 MISD = 0x4453494D
 MIRC = 0x4352494D
@@ -126,18 +110,6 @@ caps = ["valid_token"]
 args = [{name="alg",type="u32",dir="in"},{name="data",type="u8*",dir="in"},{name="len",type="usize",dir="in"},{name="out",type="u8*",dir="out"},{name="out_len",type="usize",dir="in"}]
 ret  = {type="i64"}
 
-[desc.CSGN]
-nr   = 0x4E475343
-caps = ["Crypto"]
-args = [{name="key_id",type="u64",dir="in"},{name="data",type="u8*",dir="in"},{name="len",type="usize",dir="in"},{name="sig_out",type="u8*",dir="out"},{name="sig_cap",type="usize",dir="in"}]
-ret  = {type="i64"}
-
-[desc.CVRF]
-nr   = 0x46525643
-caps = ["Crypto"]
-args = [{name="pubkey",type="u8*",dir="in"},{name="data",type="u8*",dir="in"},{name="data_len",type="usize",dir="in"},{name="sig",type="u8*",dir="in"},{name="sig_len",type="usize",dir="in"}]
-ret  = {type="i64"}
-
 [desc.CENC]
 nr   = 0x434E4543
 caps = ["Crypto"]
@@ -150,40 +122,10 @@ caps = ["Crypto"]
 args = [{name="key_id",type="u64",dir="in"},{name="ct",type="u8*",dir="in"},{name="ct_len",type="usize",dir="in"},{name="pt_out",type="u8*",dir="out"},{name="pt_cap",type="usize",dir="in"}]
 ret  = {type="i64"}
 
-[desc.CKGN]
-nr   = 0x4E474B43
-caps = ["Crypto"]
-args = [{name="alg",type="u32",dir="in"},{name="key_id_out",type="u64*",dir="out"}]
-ret  = {type="i64"}
-
-[desc.CZKP]
-nr   = 0x504B5A43
-caps = ["Crypto"]
-args = [{name="circuit_id",type="u32",dir="in"},{name="witness",type="u8*",dir="in"},{name="witness_len",type="usize",dir="in"},{name="proof_out",type="u8*",dir="out"},{name="proof_cap",type="usize",dir="in"}]
-ret  = {type="i64"}
-
-[desc.CZKV]
-nr   = 0x564B5A43
-caps = ["Crypto"]
-args = [{name="circuit_id",type="u32",dir="in"},{name="public",type="u8*",dir="in"},{name="public_len",type="usize",dir="in"},{name="proof",type="u8*",dir="in"},{name="proof_len",type="usize",dir="in"}]
-ret  = {type="i64"}
-
 [desc.CEDV]
 nr   = 0x56444543
 caps = ["Crypto"]
 args = [{name="pubkey",type="[u8;32]",dir="in"},{name="msg",type="u8*",dir="in"},{name="msg_len",type="usize",dir="in"},{name="sig",type="[u8;64]",dir="in"}]
-ret  = {type="i64"}
-
-[desc.DLOG]
-nr   = 0x474F4C44
-caps = ["Debug"]
-args = [{name="buf",type="u8*",dir="in"},{name="len",type="usize",dir="in"}]
-ret  = {type="i64"}
-
-[desc.DTRC]
-nr   = 0x43525444
-caps = ["Debug"]
-args = [{name="event_id",type="u32",dir="in"},{name="data",type="u8*",dir="in"},{name="len",type="usize",dir="in"}]
 ret  = {type="i64"}
 
 [desc.ARBT]
@@ -198,58 +140,10 @@ caps = ["Admin"]
 args = []
 ret  = {type="!"}
 
-[desc.AMOD]
-nr   = 0x444F4D41
-caps = ["Admin"]
-args = [{name="elf",type="u8*",dir="in"},{name="len",type="usize",dir="in"},{name="manifest",type="u8*",dir="in"},{name="m_len",type="usize",dir="in"}]
-ret  = {type="i64"}
-
 [desc.GDIM]
 nr   = 0x4D494447
 caps = ["GraphicsDisplayQuery"]
 args = [{name="display_id",type="u32",dir="in"},{name="dims_out",type="u8*",dir="out"}]
-ret  = {type="i64"}
-
-[desc.GSCR]
-nr   = 0x52435347
-caps = ["GraphicsSurfaceCreate"]
-args = [{name="w",type="u32",dir="in"},{name="h",type="u32",dir="in"},{name="format",type="u32",dir="in"},{name="surface_id_out",type="u32*",dir="out"}]
-ret  = {type="i64"}
-
-[desc.GSDS]
-nr   = 0x53445347
-caps = ["GraphicsSurfaceCreate"]
-args = [{name="surface_id",type="u32",dir="in"}]
-ret  = {type="i64"}
-
-[desc.GSMP]
-nr   = 0x504D5347
-caps = ["GraphicsSurfaceMap"]
-args = [{name="surface_id",type="u32",dir="in"},{name="user_vaddr_out",type="u64*",dir="out"}]
-ret  = {type="i64"}
-
-[desc.GPRF]
-nr   = 0x46525047
-caps = ["GraphicsPresent"]
-args = [{name="surface_id",type="u32",dir="in"}]
-ret  = {type="i64"}
-
-[desc.GPRR]
-nr   = 0x52525047
-caps = ["GraphicsPresent"]
-args = [{name="surface_id",type="u32",dir="in"},{name="x",type="u32",dir="in"},{name="y",type="u32",dir="in"},{name="w",type="u32",dir="in"},{name="h",type="u32",dir="in"}]
-ret  = {type="i64"}
-
-[desc.GDLS]
-nr   = 0x534C4447
-caps = ["GraphicsDisplayQuery"]
-args = [{name="buf",type="u8*",dir="out"},{name="cap",type="usize",dir="in"}]
-ret  = {type="i64"}
-
-[desc.GCUR]
-nr   = 0x52554347
-caps = ["GraphicsPresent"]
-args = [{name="surface_id",type="u32",dir="in"},{name="hx",type="u32",dir="in"},{name="hy",type="u32",dir="in"}]
 ret  = {type="i64"}
 
 [desc.MISD]

--- a/scripts/check_syscall_abi.py
+++ b/scripts/check_syscall_abi.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# NONOS Operating System
+# Copyright (C) 2026 NONOS Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Check the published syscall ABI against the numbers the kernel dispatches.
+
+`abi/syscalls.toml` is what a libc or a foreign toolchain reads to learn how
+to call this kernel. The kernel decides, in two places: the `SyscallNumber`
+enum and the microkernel `SYS_*` constants, both built from `tag4`.
+
+The only check that touched this file compared it against a handful of
+graphics IDs written into the check itself, so nothing ever compared the
+published contract to the kernel.
+
+A syscall the kernel dispatches and the ABI does not publish is not a hole,
+it is a capability nobody outside the tree can reach. The reverse is worse: a
+published number the kernel does not answer is a documented call that returns
+whatever the dispatch default happens to be.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from check_caps_abi import sections  # noqa: E402
+
+ABI = Path("abi/syscalls.toml")
+SOURCES = {
+    "enum": (Path("src/syscall/numbers/defs.rs"),
+             re.compile(r"(\w+)\s*=\s*tag4\(b\"(\w{4})\"\)")),
+    "microkernel": (Path("src/syscall/microkernel/numbers.rs"),
+                    re.compile(r"pub const (\w+)\s*:\s*u64\s*=\s*tag4\(b\"(\w{4})\"\)")),
+}
+
+
+def tag4(tag: str) -> int:
+    b = tag.encode()
+    return b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24)
+
+
+def read_kernel(root: Path):
+    """tag -> {source: rust name}. A tag may legitimately appear in both."""
+    out = {}
+    for side, (path, pattern) in SOURCES.items():
+        for name, tag in pattern.findall((root / path).read_text()):
+            out.setdefault(tag, {})[side] = name
+    return out
+
+
+def read_abi(root: Path):
+    parsed = sections((root / ABI).read_text())
+    numbers = {}
+    for key, raw in parsed.get("numbers", []):
+        numbers[key] = int(raw, 16 if raw.startswith("0x") else 10)
+    described = {s.split(".", 1)[1] for s in parsed if s.startswith("desc.")}
+    return numbers, described
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--root", type=Path, default=Path("."), help="repository root")
+    ap.add_argument("--strict", action="store_true",
+                    help="fail when a dispatched syscall is unpublished, rather "
+                         "than only listing it")
+    args = ap.parse_args()
+
+    try:
+        kernel = read_kernel(args.root)
+        published, described = read_abi(args.root)
+    except FileNotFoundError as e:
+        print(f"syscall-abi: {e}", file=sys.stderr)
+        return 2
+    if not kernel or not published:
+        print("syscall-abi: parsed an empty table, the file layout probably changed",
+              file=sys.stderr)
+        return 2
+
+    fatal, unpublished = [], []
+    for tag, value in sorted(published.items()):
+        if tag not in kernel:
+            fatal.append(f"  {tag} = 0x{value:X} is published and the kernel "
+                         f"does not dispatch it")
+        elif value != tag4(tag):
+            fatal.append(f"  {tag} DISAGREES: tag4 gives 0x{tag4(tag):X}, "
+                         f"abi says 0x{value:X}")
+        elif tag not in described:
+            fatal.append(f"  {tag} is in [numbers] with no [desc.{tag}] block")
+    for tag, names in sorted(kernel.items()):
+        if tag not in published:
+            where = ", ".join(f"{s}:{n}" for s, n in sorted(names.items()))
+            unpublished.append(f"  {tag} ({where})")
+
+    if unpublished:
+        print(f"syscall-abi: {len(unpublished)} dispatched syscalls are unpublished")
+        for line in unpublished:
+            print(line)
+    if fatal:
+        print("syscall-abi: the published ABI contradicts the kernel", file=sys.stderr)
+        for line in fatal:
+            print(line, file=sys.stderr)
+        return 1
+    if unpublished and args.strict:
+        return 1
+    print(f"syscall-abi: {len(published)} published syscalls agree with the kernel")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gen_syscall_desc.py
+++ b/scripts/gen_syscall_desc.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# NONOS Operating System
+# Copyright (C) 2026 NONOS Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Draft [desc] blocks for syscalls the ABI does not publish yet.
+
+This writes a starting point, not an answer. Argument names and types come out
+of the handler signature, which is reliable. Direction does not: a `u64` that
+happens to be a user pointer is only an out parameter if the handler writes
+through it, so this marks a pointer as `out` when the handler copies to user
+and flags anything it could not decide.
+
+Read every block it emits against the handler before publishing it. A wrong
+`[desc]` block is worse than a missing one, because a foreign toolchain will
+believe it and pass a buffer the kernel never fills.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from check_syscall_abi import read_abi, read_kernel  # noqa: E402
+
+# Two dispatch families, two spellings. The microkernel matches on SYS_
+# constants, the router matches on SyscallNumber variants, and the crypto and
+# admin calls only exist in the second.
+DISPATCH = (Path("src/syscall/microkernel/dispatch"),
+            Path("src/syscall/dispatch/router"))
+HANDLERS = (Path("src/syscall/microkernel"), Path("src/syscall/dispatch"))
+ARM = re.compile(r"(?:SYS_(\w+)|SyscallNumber::(\w+))\s*=>\s*(\w+)\(")
+# `pub fn`, but also `pub(super) fn` and `pub(in path::to) fn`, which is how
+# the admin and input handlers are declared.
+SIG = re.compile(r"pub(?:\([^)]*\))?\s+fn (\w+)\s*\(([^)]*)\)\s*->\s*([\w:<> ]+)")
+
+
+def dispatch_map(root: Path):
+    """SYS_ constant and SyscallNumber variant, both -> handler name."""
+    out = {}
+    for base in DISPATCH:
+        for path in (root / base).rglob("*.rs"):
+            for sys_const, variant, handler in ARM.findall(path.read_text()):
+                out["SYS_" + sys_const if sys_const else variant] = handler
+    return out
+
+
+def signatures(root: Path):
+    """handler -> ([(name, type)], return type, source text)."""
+    out = {}
+    for base in HANDLERS:
+        for path in (root / base).rglob("*.rs"):
+            text = path.read_text()
+            # A handler often validates and copies in sibling files, as
+            # policy_push does, so the evidence for a direction is the module
+            # rather than the one file.
+            module = "\n".join(p.read_text() for p in sorted(path.parent.glob("*.rs")))
+            for name, args, ret in SIG.findall(text):
+                parsed = []
+                for arg in (a.strip() for a in args.split(",") if a.strip()):
+                    if ":" not in arg:
+                        continue
+                    an, at = arg.split(":", 1)
+                    parsed.append((an.strip(), at.strip()))
+                out[name] = (parsed, ret.strip(), module)
+    return out
+
+
+# The usercopy primitives, plus the thin `copy::` wrappers the crypto handlers
+# use. A turbofish may sit between the name and the paren, as in
+# `copy::read_array::<32>(ptr)`.
+WRITES = ("write_user_bytes", "copy_to_user", "write_user_value",
+          "validate_user_write", "copy::write", "copy::write_result")
+READS = ("read_user_bytes", "copy_from_user", "read_user_value",
+         "read_user_string", "validate_user_read", "copy::read_array",
+         "copy::read_slice", "copy::read_vec",
+         # a local reader in the hmac handler, one level above copy::read_vec
+         "read_optional")
+POINTER_NAME = re.compile(r"ptr|buf|addr|_out\b|^out|data|msg|name|path")
+
+
+def direction(arg_name: str, arg_type: str, body: str):
+    """Direction, and whether the handler actually showed us.
+
+    Decided by which usercopy primitive the handler passes the argument to,
+    since that is the only evidence in the source. A pointer the handler never
+    hands to one of them is reported as undecided rather than guessed: a
+    caller who believes a wrong `out` passes a buffer nobody fills.
+    """
+    # A length is a scalar however it is named. `out_len` and `name_len` sit
+    # next to a pointer, they are not one.
+    is_len = arg_name == "len" or arg_name.endswith("_len")
+    pointerish = not is_len and ("*" in arg_type or POINTER_NAME.search(arg_name))
+    if not pointerish:
+        # A scalar cannot be an out parameter. Nothing is carried back through
+        # a pid or a timeout, so no evidence is needed to call it in.
+        return "in", True
+    for fns, answer in ((WRITES, "out"), (READS, "in")):
+        for fn in fns:
+            pat = rf"{re.escape(fn)}(?:::<[^>]*>)?\(\s*{re.escape(arg_name)}\b"
+            if re.search(pat, body):
+                return answer, True
+    return "in", False
+
+
+def block(tag: str, handler: str, sig):
+    args, ret, body = sig
+    parts, unsure = [], []
+    for name, ty in args:
+        d, certain = direction(name, ty, body)
+        if not certain:
+            unsure.append(name)
+        parts.append(f'{{name="{name}",type="{ty}",dir="{d}"}}')
+    b = int.from_bytes(tag.encode(), "little")
+    # SyscallResult is the in-kernel carrier. What crosses the boundary is the
+    # i64 in its value field, which is what the published entries already say.
+    wire = "i64" if ret in ("SyscallResult", "i64") else ret
+    lines = [f"[desc.{tag}]",
+             f"nr   = 0x{b:08X}",
+             'caps = ["valid_token"]',
+             f"args = [{','.join(parts)}]",
+             f'ret  = {{type="{wire}"}}']
+    if unsure:
+        lines.insert(0, f"# CHECK {handler}: direction unverified for "
+                        + ", ".join(unsure))
+    return "\n".join(lines), bool(unsure)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--root", type=Path, default=Path("."), help="repository root")
+    args = ap.parse_args()
+
+    kernel = read_kernel(args.root)
+    published, _ = read_abi(args.root)
+    arms = dispatch_map(args.root)
+    sigs = signatures(args.root)
+    by_const = {c: h for c, h in arms.items()}
+
+    drafted, undecided, flagged = [], [], 0
+    for tag, names in sorted(kernel.items()):
+        if tag in published:
+            continue
+        const = names.get("microkernel") or names.get("enum")
+        handler = by_const.get(const) if const else None
+        if handler and handler in sigs:
+            text, unsure = block(tag, handler, sigs[handler])
+            drafted.append(text)
+            flagged += unsure
+        else:
+            undecided.append(f"# {tag}: no handler found via "
+                             f"{const or 'the enum only'}, write by hand")
+
+    print("\n\n".join(drafted))
+    if undecided:
+        print("\n".join(undecided), file=sys.stderr)
+    print(f"{len(drafted)} drafted, {flagged} carry an unverified direction, "
+          f"{len(undecided)} need writing by hand", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stacked on #442.

Nothing has ever compared `abi/syscalls.toml` to the kernel. The one check that read the file verified four graphics IDs written into the check itself, so it pinned the stale entries in place rather than catching them. Same shape as the `abi/caps.toml` check in #442.

## What the file claimed

15 syscalls that the kernel does not define anywhere:

    GSCR GSMP GPRF GPRR GSDS GCUR GDLS   surface create/map/present/destroy, cursor, display list
    CSGN CVRF CKGN CZKP CZKV             crypto sign, verify, keygen, zk prove, zk verify
    AMOD DLOG DTRC                       admin mode, debug log, debug trace

The graphics six were retired deliberately, and `src/syscall/abi/registry/graphics.rs` says so:

> Only the display-dimensions query remains in the kernel; surface create/map/present and the cursor/display-list calls were retired in favor of the MkSurface* path served by the surface registry and the compositor capsule.

The crypto five have no implementation and appear never to have had one.

## What it omits

45 syscalls the kernel dispatches are not published at all, including every `Mk*` call the microkernel serves and the crypto primitives that do exist (`CHKF`, `CHMC`, `CKEC`, `CEDS`, `CXPK`). Those are listed by the checker but not treated as failures, because each needs a real `[desc]` block with argument names, types and directions, and that has to be written from the implementation rather than generated.

## Worth a separate look

`userland/libc` still exports wrappers over four of the retired numbers: `surface_create`, `surface_map`, `surface_present` and `surface_present_rect` in `userland/libc/src/graphics/`. They call tags the kernel does not define, so they cannot succeed. Removing them or porting them to the `MkSurface` path is a userland change and is not in this PR.

The CI check that pinned the retired IDs is NON-OS/nonos-ci#3.

## Testing

Not booted. The checker is deterministic and runs in under a second:

    python3 scripts/check_syscall_abi.py