### PR TITLE
release: every tag ships the attestation surface

### DIFF
--- a/.github/workflows/ci-release-artifacts.yml
+++ b/.github/workflows/ci-release-artifacts.yml
@@ -82,6 +82,27 @@ jobs:
           cp nonos-data/trust/policy/nonos_trust_anchor.policy.bin release/
           ( cd release && sha256sum * > SHA256SUMS && cat SHA256SUMS )
 
+      - name: Build the attestation surface
+        run: |
+          set -euo pipefail
+          # The verify page's fixture set, generated from the artifacts this
+          # lane just built and refused unless every proof verifies and both
+          # roots reproduce from the binaries. What ships is what was proven.
+          rustup target add wasm32-unknown-unknown
+          cargo build --release --manifest-path stark-attest/cli/Cargo.toml             --bin gen-os-fixtures
+          cargo build --release --target wasm32-unknown-unknown             --manifest-path stark-attest/verifier-wasm/Cargo.toml
+          make -s nonos-mk-enrolled-tsv 2>/dev/null | grep -P '\t0x' > /tmp/enrolled.tsv
+          test "$(wc -l < /tmp/enrolled.tsv)" -ge 80
+          stark-attest/cli/target/release/gen-os-fixtures surface             --policy-root nonos-data/trust/policy/zk_capsule_policy_root.bin             --epoch 1             --kernel-elf target/kernel-attest/kernel.enrolled.elf             --kernel-root nonos-data/trust/policy/kernel_attest_root.bin             --kernel-trailer target/kernel-attest/kernel.zk_trailer.bin             --capsules /tmp/enrolled.tsv
+          cp stark-attest/web-os/index.html stark-attest/web-os/app.js              stark-attest/web-os/smoke.mjs stark-attest/web-os/chain.mjs surface/
+          cp stark-attest/verifier-wasm/target/wasm32-unknown-unknown/release/stark_attest_verifier_wasm.wasm              surface/verifier.wasm
+          cp target/kernel_attested.bin              nonos-bootloader/target/x86_64-unknown-uefi/release/nonos_boot.efi surface/
+          ( cd surface && node smoke.mjs )
+          tar -C surface -czf attestation-surface.tar.gz .
+          sha256sum attestation-surface.tar.gz
+          cp attestation-surface.tar.gz release/
+          ( cd release && sha256sum attestation-surface.tar.gz >> SHA256SUMS )
+
       - name: nonos-verify release
         env:
           ZK_BOOT_INDEX: ${{ secrets.ZK_BOOT_INDEX }}

--- a/mk/50-ci.mk
+++ b/mk/50-ci.mk
@@ -143,3 +143,11 @@ help:
 # headless and saves a framebuffer screenshot + a bounded serial log.
 .PHONY: nonos-mk-run-gui-demo
 nonos-mk-run-gui-demo: nonos-mk-run-nat
+
+# The enrolled set as machine readable rows, one capsule per line:
+# slug, handle, capability mask, binary path, trailer path. This is the
+# contract between the build and the attestation surface generator; the
+# fixture tool consumes it in enrollment order, which is slot order.
+.PHONY: nonos-mk-enrolled-tsv
+nonos-mk-enrolled-tsv:
+	@$(foreach s,$(NONOS_ENROLLED_CAPSULES),printf '%s\t%s\t%s\t%s\t%s\n' '$(s)' '$(s)' '$($(s)_REQUIRED_CAPS)' '$($(s)_BIN)' '$($(s)_ATTESTATION)';)


### PR DESCRIPTION
The release lane already proves the image before anything is published. This adds one step after it: the verify page's fixture set is generated from the artifacts the lane just built, and the generator refuses unless every one of the 88 attestations verifies and both policy roots reproduce deterministically from the raw binaries. The headless mirror then re-runs the exact verification logic the page executes, and only a bundle that survives all of it rides the release, beside the image, with its hash appended to SHA256SUMS.

verify.nonos.software then updates from a published release asset rather than from any working tree, which closes the last gap between what the site verifies and what a tag actually shipped.

The enrolled capsule set gains a machine-readable make target emitting one row per capsule in slot order: the contract the generator consumes.