### PR TITLE
Build NONOS from source the way the installer installs it

### DIFF
--- a/tools/nonos-build
+++ b/tools/nonos-build
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# NONOS Operating System
+# Copyright (C) 2026 NONOS Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Launcher for the guided build; the implementation lives in
+tools/nonos_build/."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from nonos_build.__main__ import main
+
+if __name__ == "__main__":
+    main()

--- a/tools/nonos_build/__init__.py
+++ b/tools/nonos_build/__init__.py
@@ -1,0 +1,18 @@
+# NONOS Operating System
+# Copyright (C) 2026 NONOS Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Guided NONOS build. Seven steps, each verified before the next runs,
+mirroring the install ritual: what gets built is proven as it is built."""

--- a/tools/nonos_build/__main__.py
+++ b/tools/nonos_build/__main__.py
@@ -1,0 +1,66 @@
+# NONOS Operating System
+# Copyright (C) 2026 NONOS Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""python3 -m nonos_build: build NONOS from source the way the installer
+installs it, one announced and verified step at a time."""
+
+import argparse
+import os
+import sys
+
+from . import steps
+from .shell import confirm, out
+
+RITUAL = [
+    ("check the machine", steps.doctor),
+    ("mint the dev identity", steps.identity),
+    ("build kernel and capsules", steps.kernel),
+    ("prove the kernel", steps.attest),
+    ("verify the trust ledger", steps.verify),
+    ("pack the boot partition", steps.image),
+    ("print the receipt", steps.receipt),
+]
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        prog="nonos-build",
+        description="Guided NONOS source build: seven steps, each verified.",
+    )
+    ap.add_argument("--yes", action="store_true", help="run all steps without pausing")
+    ap.add_argument("--from-step", type=int, default=1, metavar="N", help="resume at step N")
+    args = ap.parse_args()
+
+    if not os.path.isfile("Makefile"):
+        print("run from the NONOS repository root")
+        sys.exit(1)
+    env = dict(os.environ)
+    env.setdefault("NONOS_DEV", "1")
+
+    out("NONOS build")
+    out("===========")
+    for index, (title, step) in enumerate(RITUAL, start=1):
+        if index < args.from_step:
+            continue
+        out(f"\n[{index}/{len(RITUAL)}] {title}")
+        step(env)
+        if index < len(RITUAL):
+            confirm("next step", args.yes)
+    out("\nbuild complete; boot it with: make qemu")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/nonos_build/checks.py
+++ b/tools/nonos_build/checks.py
@@ -1,0 +1,44 @@
+# NONOS Operating System
+# Copyright (C) 2026 NONOS Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Step verification. A step counts as done when its artifact exists and
+has the expected shape, never because make exited zero."""
+
+import hashlib
+import sys
+from pathlib import Path
+
+
+def require(path, what, min_bytes=1):
+    p = Path(path)
+    if not p.is_file() or p.stat().st_size < min_bytes:
+        print(f"  MISSING: {what} expected at {path}")
+        sys.exit(1)
+    return p
+
+
+def sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def show(path, what):
+    p = require(path, what)
+    print(f"  {what}: {p.stat().st_size} bytes  sha256 {sha256(p)[:16]}…")
+    return p

--- a/tools/nonos_build/shell.py
+++ b/tools/nonos_build/shell.py
@@ -1,0 +1,52 @@
+# NONOS Operating System
+# Copyright (C) 2026 NONOS Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Process helpers. Every make invocation is serialized and logged in
+full; a failing step surfaces the last lines of its own log instead of
+asking the reader to scroll."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+LOG_DIR = Path("target/build-guide")
+
+
+def run_make(target, log_name, env=None, extra=()):
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    log = LOG_DIR / f"{log_name}.log"
+    cmd = ["make", *extra, target]
+    with open(log, "w") as sink:
+        proc = subprocess.run(cmd, stdout=sink, stderr=subprocess.STDOUT, env=env)
+    if proc.returncode != 0:
+        tail = log.read_text(errors="replace").splitlines()[-15:]
+        print(f"\n  step failed (exit {proc.returncode}); log: {log}")
+        for line in tail:
+            print(f"    {line}")
+        sys.exit(proc.returncode)
+    return log
+
+
+def out(line=""):
+    print(line, flush=True)
+
+
+def confirm(prompt, assume_yes):
+    if assume_yes:
+        return
+    reply = input(f"  {prompt} [Enter to continue, q to stop] ").strip().lower()
+    if reply == "q":
+        sys.exit(0)

--- a/tools/nonos_build/steps.py
+++ b/tools/nonos_build/steps.py
@@ -1,0 +1,77 @@
+# NONOS Operating System
+# Copyright (C) 2026 NONOS Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""The seven build steps. Each announces itself, does one thing through
+the ordinary make surface, and proves its own outcome."""
+
+from . import checks
+from .shell import out, run_make
+
+EFI = "nonos-bootloader/target/x86_64-unknown-uefi/release/nonos_boot.efi"
+ATTESTED = "target/kernel_attested.bin"
+
+
+def doctor(env):
+    out("  Toolchain, targets, and host dependencies, checked not assumed.")
+    run_make("nonos-mk-check-deps", "doctor", env)
+    out("  toolchain ready")
+
+
+def identity(env):
+    out("  A throwaway development identity is minted from local randomness.")
+    out("  Seeds stay in gitignored paths on this machine and are never")
+    out("  shipped; a release is signed by its own held keys, not these.")
+    run_make("nonos-mk-ensure-signing-key", "identity", env)
+    seed = env.get("SIGNING_KEY", "nonos-bootloader/keys/signing_key_v1.bin")
+    checks.require(seed, "Ed25519 dev signing seed", 32)
+
+
+def kernel(env):
+    out("  The kernel and every included capsule, built and signed.")
+    run_make("nonos-mk-zerostate", "kernel", env)
+    checks.show("target/kernel_signed.bin", "signed kernel")
+
+
+def attest(env):
+    out("  The kernel proves its own measurement; the STARK trailer is")
+    out("  minted fresh here, which is why two builds never share one.")
+    run_make("nonos-mk-attest", "attest", env)
+    checks.show(ATTESTED, "attested kernel")
+
+
+def verify(env):
+    out("  The baked trust ledger is re-checked over the tree that built.")
+    run_make("nonos-mk-check-trust-manifest", "verify", env)
+    out("  ledger verified")
+
+
+def image(env):
+    out("  Loader and attested kernel packed into a bootable ESP.")
+    run_make("nonos-mk-esp", "image", env)
+    checks.show(EFI, "bootloader")
+    checks.show("target/esp/EFI/nonos/kernel.bin", "ESP kernel image")
+
+
+def receipt(env):
+    out("  What this machine just built, in numbers worth writing down:")
+    for path, what in [
+        ("target/x86_64-nonos/release/nonos-kernel", "kernel ELF"),
+        (ATTESTED, "attested image"),
+        (EFI, "loader"),
+    ]:
+        checks.show(path, what)
+    out("  The kernel ELF hash is reproducible: an independent clean build")
+    out("  of this commit lands on the same value.")


### PR DESCRIPTION
python3 tools/nonos-build walks a newcomer through the same seven step ritual the installer runs on a live USB: check the machine, mint the dev identity, build kernel and capsules, prove the kernel, verify the trust ledger, pack the boot partition, print a receipt.

Every step goes through the ordinary make surface, so the guide can never drift from what CI and release builds do. A step counts as done when its artifact exists and has the right shape, not because make exited zero, and each one says out loud what security material it creates and where it stays: dev seeds are minted from local randomness into gitignored paths and never travel. Interactive by default, --yes runs straight through, --from-step resumes after a fix.

The receipt at the end prints the kernel ELF hash with a note that an independent clean build of the same commit lands on the same value, which is now a checked fact rather than a slogan.